### PR TITLE
Replace mocks with fakes and builders for improved tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,7 +68,6 @@ dependencies {
     implementation(libs.kotlinx.collections.immutable)
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.test)
-    testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/timur/gilfanov/messenger/domain/entity/chat/validation/ChatValidator.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/entity/chat/validation/ChatValidator.kt
@@ -1,78 +1,8 @@
 package timur.gilfanov.messenger.domain.entity.chat.validation
 
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.ImmutableSet
 import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.chat.Chat
-import timur.gilfanov.messenger.domain.entity.chat.Participant
-import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError.EmptyName
-import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError.NoParticipants
-import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError.NonEmptyMessages
-import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError.NonNullLastReadMessageId
-import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError.NonZeroUnreadCount
-import timur.gilfanov.messenger.domain.entity.isFailure
-import timur.gilfanov.messenger.domain.entity.message.Message
-import timur.gilfanov.messenger.domain.entity.message.MessageId
 
-class ChatValidator {
-    fun validate(chat: Chat): ResultWithError<Unit, ChatValidationError> {
-        val participantsResult = validateParticipants(chat.participants)
-        if (participantsResult.isFailure) {
-            return participantsResult
-        } else {
-            val nameResult = validateName(chat.name)
-            return if (nameResult.isFailure) nameResult else ResultWithError.Success(Unit)
-        }
-    }
-
-    fun validateOnCreation(chat: Chat): ResultWithError<Unit, ChatValidationError> = when {
-        validate(chat).isFailure -> validate(chat)
-        validateMessagesOnCreation(
-            chat.messages,
-        ).isFailure -> validateMessagesOnCreation(chat.messages)
-        validateUnreadMessagesCountOnCreation(chat.unreadMessagesCount).isFailure ->
-            validateUnreadMessagesCountOnCreation(chat.unreadMessagesCount)
-        validateLastReadMessageIdOnCreation(chat.lastReadMessageId).isFailure ->
-            validateLastReadMessageIdOnCreation(chat.lastReadMessageId)
-        else -> ResultWithError.Success(Unit)
-    }
-
-    fun validateParticipants(
-        participants: ImmutableSet<Participant>,
-    ): ResultWithError<Unit, ChatValidationError> = if (participants.isEmpty()) {
-        ResultWithError.Failure(NoParticipants)
-    } else {
-        ResultWithError.Success(Unit)
-    }
-
-    fun validateName(name: String): ResultWithError<Unit, ChatValidationError> =
-        if (name.isBlank()) {
-            ResultWithError.Failure(EmptyName)
-        } else {
-            ResultWithError.Success(Unit)
-        }
-
-    fun validateMessagesOnCreation(
-        messages: ImmutableList<Message>,
-    ): ResultWithError<Unit, ChatValidationError> = if (messages.isNotEmpty()) {
-        ResultWithError.Failure(NonEmptyMessages)
-    } else {
-        ResultWithError.Success(Unit)
-    }
-
-    fun validateUnreadMessagesCountOnCreation(
-        unreadMessagesCount: Int,
-    ): ResultWithError<Unit, ChatValidationError> = if (unreadMessagesCount != 0) {
-        ResultWithError.Failure(NonZeroUnreadCount)
-    } else {
-        ResultWithError.Success(Unit)
-    }
-
-    fun validateLastReadMessageIdOnCreation(
-        lastReadMessageId: MessageId?,
-    ): ResultWithError<Unit, ChatValidationError> = if (lastReadMessageId != null) {
-        ResultWithError.Failure(NonNullLastReadMessageId)
-    } else {
-        ResultWithError.Success(Unit)
-    }
+interface ChatValidator {
+    fun validateOnCreation(chat: Chat): ResultWithError<Unit, ChatValidationError>
 }

--- a/app/src/main/java/timur/gilfanov/messenger/domain/entity/chat/validation/ChatValidatorImpl.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/entity/chat/validation/ChatValidatorImpl.kt
@@ -1,0 +1,78 @@
+package timur.gilfanov.messenger.domain.entity.chat.validation
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
+import timur.gilfanov.messenger.domain.entity.ResultWithError
+import timur.gilfanov.messenger.domain.entity.chat.Chat
+import timur.gilfanov.messenger.domain.entity.chat.Participant
+import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError.EmptyName
+import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError.NoParticipants
+import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError.NonEmptyMessages
+import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError.NonNullLastReadMessageId
+import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError.NonZeroUnreadCount
+import timur.gilfanov.messenger.domain.entity.isFailure
+import timur.gilfanov.messenger.domain.entity.message.Message
+import timur.gilfanov.messenger.domain.entity.message.MessageId
+
+class ChatValidatorImpl : ChatValidator {
+    fun validate(chat: Chat): ResultWithError<Unit, ChatValidationError> {
+        val participantsResult = validateParticipants(chat.participants)
+        if (participantsResult.isFailure) {
+            return participantsResult
+        } else {
+            val nameResult = validateName(chat.name)
+            return if (nameResult.isFailure) nameResult else ResultWithError.Success(Unit)
+        }
+    }
+
+    override fun validateOnCreation(chat: Chat): ResultWithError<Unit, ChatValidationError> = when {
+        validate(chat).isFailure -> validate(chat)
+        validateMessagesOnCreation(
+            chat.messages,
+        ).isFailure -> validateMessagesOnCreation(chat.messages)
+        validateUnreadMessagesCountOnCreation(chat.unreadMessagesCount).isFailure ->
+            validateUnreadMessagesCountOnCreation(chat.unreadMessagesCount)
+        validateLastReadMessageIdOnCreation(chat.lastReadMessageId).isFailure ->
+            validateLastReadMessageIdOnCreation(chat.lastReadMessageId)
+        else -> ResultWithError.Success(Unit)
+    }
+
+    fun validateParticipants(
+        participants: ImmutableSet<Participant>,
+    ): ResultWithError<Unit, ChatValidationError> = if (participants.isEmpty()) {
+        ResultWithError.Failure(NoParticipants)
+    } else {
+        ResultWithError.Success(Unit)
+    }
+
+    fun validateName(name: String): ResultWithError<Unit, ChatValidationError> =
+        if (name.isBlank()) {
+            ResultWithError.Failure(EmptyName)
+        } else {
+            ResultWithError.Success(Unit)
+        }
+
+    fun validateMessagesOnCreation(
+        messages: ImmutableList<Message>,
+    ): ResultWithError<Unit, ChatValidationError> = if (messages.isNotEmpty()) {
+        ResultWithError.Failure(NonEmptyMessages)
+    } else {
+        ResultWithError.Success(Unit)
+    }
+
+    fun validateUnreadMessagesCountOnCreation(
+        unreadMessagesCount: Int,
+    ): ResultWithError<Unit, ChatValidationError> = if (unreadMessagesCount != 0) {
+        ResultWithError.Failure(NonZeroUnreadCount)
+    } else {
+        ResultWithError.Success(Unit)
+    }
+
+    fun validateLastReadMessageIdOnCreation(
+        lastReadMessageId: MessageId?,
+    ): ResultWithError<Unit, ChatValidationError> = if (lastReadMessageId != null) {
+        ResultWithError.Failure(NonNullLastReadMessageId)
+    } else {
+        ResultWithError.Success(Unit)
+    }
+}

--- a/app/src/main/java/timur/gilfanov/messenger/domain/entity/message/validation/DeliveryStatusValidator.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/entity/message/validation/DeliveryStatusValidator.kt
@@ -1,83 +1,11 @@
 package timur.gilfanov.messenger.domain.entity.message.validation
 
 import timur.gilfanov.messenger.domain.entity.ResultWithError
-import timur.gilfanov.messenger.domain.entity.ResultWithError.Failure
-import timur.gilfanov.messenger.domain.entity.ResultWithError.Success
 import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus
-import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Delivered
-import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Failed
-import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Read
-import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Sending
-import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Sent
-import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeAnyStatusToUndefined
-import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromDeliveredToFailed
-import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromDeliveredToSending
-import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromDeliveredToSent
-import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromRead
-import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromSentToFailed
-import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromSentToSending
-import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromUndefinedToOtherThanSending
 
-class DeliveryStatusValidator {
-
-    private val validTransitions = mapOf(
-        Read::class to emptySet(),
-        Delivered::class to setOf(Delivered::class, Read::class),
-        Sent::class to setOf(Sent::class, Delivered::class, Read::class),
-        Failed::class to setOf(
-            Failed::class,
-            Sending::class,
-            Sent::class,
-            Delivered::class,
-            Read::class,
-        ),
-        Sending::class to setOf(
-            Sending::class,
-            Failed::class,
-            Sent::class,
-            Delivered::class,
-            Read::class,
-        ),
-        null to setOf(Sending::class),
-    )
-
-    private val transitionErrors = mapOf(
-        Pair(Read::class, null) to CannotChangeFromRead,
-        Pair(Read::class, Sending::class) to CannotChangeFromRead,
-        Pair(Read::class, Failed::class) to CannotChangeFromRead,
-        Pair(Read::class, Sent::class) to CannotChangeFromRead,
-        Pair(Read::class, Delivered::class) to CannotChangeFromRead,
-        Pair(Delivered::class, null) to CannotChangeAnyStatusToUndefined,
-        Pair(Delivered::class, Sending::class) to CannotChangeFromDeliveredToSending,
-        Pair(Delivered::class, Failed::class) to CannotChangeFromDeliveredToFailed,
-        Pair(Delivered::class, Sent::class) to CannotChangeFromDeliveredToSent,
-        Pair(Sent::class, null) to CannotChangeAnyStatusToUndefined,
-        Pair(Sent::class, Sending::class) to CannotChangeFromSentToSending,
-        Pair(Sent::class, Failed::class) to CannotChangeFromSentToFailed,
-        Pair(Failed::class, null) to CannotChangeAnyStatusToUndefined,
-        Pair(Sending::class, null) to CannotChangeAnyStatusToUndefined,
-        Pair(null, null) to CannotChangeFromUndefinedToOtherThanSending,
-        Pair(null, Failed::class) to CannotChangeFromUndefinedToOtherThanSending,
-        Pair(null, Sent::class) to CannotChangeFromUndefinedToOtherThanSending,
-        Pair(null, Delivered::class) to CannotChangeFromUndefinedToOtherThanSending,
-        Pair(null, Read::class) to CannotChangeFromUndefinedToOtherThanSending,
-
-    )
-
+interface DeliveryStatusValidator {
     fun validate(
         currentStatus: DeliveryStatus?,
         newStatus: DeliveryStatus?,
-    ): ResultWithError<Unit, DeliveryStatusValidationError> {
-        val currentStatusClass = currentStatus?.let { it::class }
-        val newStatusClass = newStatus?.let { it::class }
-
-        validTransitions[currentStatusClass]?.let { allowedTransitions ->
-            if (newStatusClass in allowedTransitions) {
-                return Success(Unit)
-            }
-        }
-
-        val error = transitionErrors[Pair(currentStatusClass, newStatusClass)]!!
-        return Failure(error)
-    }
+    ): ResultWithError<Unit, DeliveryStatusValidationError>
 }

--- a/app/src/main/java/timur/gilfanov/messenger/domain/entity/message/validation/DeliveryStatusValidatorImpl.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/entity/message/validation/DeliveryStatusValidatorImpl.kt
@@ -1,0 +1,83 @@
+package timur.gilfanov.messenger.domain.entity.message.validation
+
+import timur.gilfanov.messenger.domain.entity.ResultWithError
+import timur.gilfanov.messenger.domain.entity.ResultWithError.Failure
+import timur.gilfanov.messenger.domain.entity.ResultWithError.Success
+import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus
+import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Delivered
+import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Failed
+import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Read
+import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Sending
+import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Sent
+import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeAnyStatusToUndefined
+import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromDeliveredToFailed
+import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromDeliveredToSending
+import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromDeliveredToSent
+import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromRead
+import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromSentToFailed
+import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromSentToSending
+import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError.CannotChangeFromUndefinedToOtherThanSending
+
+class DeliveryStatusValidatorImpl : DeliveryStatusValidator {
+
+    private val validTransitions = mapOf(
+        Read::class to emptySet(),
+        Delivered::class to setOf(Delivered::class, Read::class),
+        Sent::class to setOf(Sent::class, Delivered::class, Read::class),
+        Failed::class to setOf(
+            Failed::class,
+            Sending::class,
+            Sent::class,
+            Delivered::class,
+            Read::class,
+        ),
+        Sending::class to setOf(
+            Sending::class,
+            Failed::class,
+            Sent::class,
+            Delivered::class,
+            Read::class,
+        ),
+        null to setOf(Sending::class),
+    )
+
+    private val transitionErrors = mapOf(
+        Pair(Read::class, null) to CannotChangeFromRead,
+        Pair(Read::class, Sending::class) to CannotChangeFromRead,
+        Pair(Read::class, Failed::class) to CannotChangeFromRead,
+        Pair(Read::class, Sent::class) to CannotChangeFromRead,
+        Pair(Read::class, Delivered::class) to CannotChangeFromRead,
+        Pair(Delivered::class, null) to CannotChangeAnyStatusToUndefined,
+        Pair(Delivered::class, Sending::class) to CannotChangeFromDeliveredToSending,
+        Pair(Delivered::class, Failed::class) to CannotChangeFromDeliveredToFailed,
+        Pair(Delivered::class, Sent::class) to CannotChangeFromDeliveredToSent,
+        Pair(Sent::class, null) to CannotChangeAnyStatusToUndefined,
+        Pair(Sent::class, Sending::class) to CannotChangeFromSentToSending,
+        Pair(Sent::class, Failed::class) to CannotChangeFromSentToFailed,
+        Pair(Failed::class, null) to CannotChangeAnyStatusToUndefined,
+        Pair(Sending::class, null) to CannotChangeAnyStatusToUndefined,
+        Pair(null, null) to CannotChangeFromUndefinedToOtherThanSending,
+        Pair(null, Failed::class) to CannotChangeFromUndefinedToOtherThanSending,
+        Pair(null, Sent::class) to CannotChangeFromUndefinedToOtherThanSending,
+        Pair(null, Delivered::class) to CannotChangeFromUndefinedToOtherThanSending,
+        Pair(null, Read::class) to CannotChangeFromUndefinedToOtherThanSending,
+
+    )
+
+    override fun validate(
+        currentStatus: DeliveryStatus?,
+        newStatus: DeliveryStatus?,
+    ): ResultWithError<Unit, DeliveryStatusValidationError> {
+        val currentStatusClass = currentStatus?.let { it::class }
+        val newStatusClass = newStatus?.let { it::class }
+
+        validTransitions[currentStatusClass]?.let { allowedTransitions ->
+            if (newStatusClass in allowedTransitions) {
+                return Success(Unit)
+            }
+        }
+
+        val error = transitionErrors[Pair(currentStatusClass, newStatusClass)]!!
+        return Failure(error)
+    }
+}

--- a/app/src/main/java/timur/gilfanov/messenger/domain/usecase/CreateChatError.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/usecase/CreateChatError.kt
@@ -2,7 +2,14 @@ package timur.gilfanov.messenger.domain.usecase
 
 import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError
 
-sealed class CreateChatError {
-    data class ChatIsNotValid(val error: ChatValidationError) : CreateChatError()
-    data class RepositoryCreateChatError(val error: RepositoryError) : CreateChatError()
+sealed class CreateChatError
+
+data class ChatIsNotValid(val error: ChatValidationError) : CreateChatError()
+
+sealed class RepositoryCreateChatError : CreateChatError() {
+    object NetworkNotAvailable : RepositoryCreateChatError()
+    object ServerUnreachable : RepositoryCreateChatError()
+    object ServerError : RepositoryCreateChatError()
+    object UnknownError : RepositoryCreateChatError()
+    object DuplicateChatId : RepositoryCreateChatError()
 }

--- a/app/src/main/java/timur/gilfanov/messenger/domain/usecase/CreateChatUseCase.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/usecase/CreateChatUseCase.kt
@@ -5,13 +5,12 @@ import timur.gilfanov.messenger.domain.entity.ResultWithError.Failure
 import timur.gilfanov.messenger.domain.entity.ResultWithError.Success
 import timur.gilfanov.messenger.domain.entity.chat.Chat
 import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidator
-import timur.gilfanov.messenger.domain.usecase.CreateChatError.ChatIsNotValid
-import timur.gilfanov.messenger.domain.usecase.CreateChatError.RepositoryCreateChatError
+import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidatorImpl
 
 class CreateChatUseCase(
     private val chat: Chat,
     private val repository: Repository,
-    private val validator: ChatValidator = ChatValidator(),
+    private val validator: ChatValidator = ChatValidatorImpl(),
 ) {
     suspend operator fun invoke(): ResultWithError<Chat, CreateChatError> {
         val validation = validator.validateOnCreation(chat)
@@ -22,7 +21,7 @@ class CreateChatUseCase(
         val result = repository.createChat(chat)
         return when (result) {
             is Success -> Success(result.data)
-            is Failure -> Failure(RepositoryCreateChatError(result.error))
+            is Failure -> Failure(result.error)
         }
     }
 }

--- a/app/src/main/java/timur/gilfanov/messenger/domain/usecase/Repository.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/usecase/Repository.kt
@@ -9,7 +9,7 @@ import timur.gilfanov.messenger.domain.entity.message.Message
 interface Repository {
     suspend fun sendMessage(message: Message): Flow<Message>
     suspend fun editMessage(message: Message): Flow<Message>
-    suspend fun createChat(chat: Chat): ResultWithError<Chat, RepositoryError>
+    suspend fun createChat(chat: Chat): ResultWithError<Chat, RepositoryCreateChatError>
     suspend fun receiveChatUpdates(
         chatId: ChatId,
     ): Flow<ResultWithError<Chat, ReceiveChatUpdatesError>>

--- a/app/src/test/java/timur/gilfanov/messenger/data/repository/RepositoryFake.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/data/repository/RepositoryFake.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import timur.gilfanov.messenger.domain.entity.ResultWithError
-import timur.gilfanov.messenger.domain.entity.ResultWithError.Success
 import timur.gilfanov.messenger.domain.entity.chat.Chat
 import timur.gilfanov.messenger.domain.entity.chat.ChatId
 import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus
@@ -19,7 +18,7 @@ import timur.gilfanov.messenger.domain.entity.message.Message
 import timur.gilfanov.messenger.domain.entity.message.TextMessage
 import timur.gilfanov.messenger.domain.usecase.ReceiveChatUpdatesError
 import timur.gilfanov.messenger.domain.usecase.Repository
-import timur.gilfanov.messenger.domain.usecase.RepositoryError
+import timur.gilfanov.messenger.domain.usecase.RepositoryCreateChatError
 
 class RepositoryFake : Repository {
     private val chats = mutableMapOf<ChatId, Chat>()
@@ -30,10 +29,10 @@ class RepositoryFake : Repository {
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
 
-    override suspend fun createChat(chat: Chat): ResultWithError<Chat, RepositoryError> {
+    override suspend fun createChat(chat: Chat): ResultWithError<Chat, RepositoryCreateChatError> {
         chats[chat.id] = chat
         chatUpdates.emit(chat)
-        return Success(chat)
+        return ResultWithError.Success(chat)
     }
 
     override suspend fun sendMessage(message: Message): Flow<Message> {
@@ -90,9 +89,9 @@ class RepositoryFake : Repository {
 
         return chatUpdates
             .filter { it.id == chatId }
-            .map { Success<Chat, ReceiveChatUpdatesError>(it) }
+            .map { ResultWithError.Success<Chat, ReceiveChatUpdatesError>(it) }
             .onStart {
-                initialChat?.let { emit(Success(it)) }
+                initialChat?.let { emit(ResultWithError.Success(it)) }
             }
             .distinctUntilChanged()
     }

--- a/app/src/test/java/timur/gilfanov/messenger/domain/entity/chat/ChatBuilder.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/entity/chat/ChatBuilder.kt
@@ -1,0 +1,33 @@
+package timur.gilfanov.messenger.domain.entity.chat
+
+import java.util.UUID
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+import timur.gilfanov.messenger.domain.entity.message.Message
+import timur.gilfanov.messenger.domain.entity.message.MessageId
+
+fun buildChat(builder: ChatBuilder.() -> Unit): Chat = ChatBuilder().apply(builder).build()
+
+class ChatBuilder {
+    var id: ChatId = ChatId(UUID.randomUUID())
+    var name: String = "Test Chat"
+    var pictureUrl: String? = null
+    var messages: ImmutableList<Message> = persistentListOf()
+    var participants: ImmutableSet<Participant> = persistentSetOf()
+    var rules: ImmutableSet<Rule> = persistentSetOf()
+    var unreadMessagesCount: Int = 0
+    var lastReadMessageId: MessageId? = null
+
+    fun build(): Chat = Chat(
+        id = id,
+        name = name,
+        pictureUrl = pictureUrl,
+        messages = messages,
+        participants = participants,
+        rules = rules,
+        unreadMessagesCount = unreadMessagesCount,
+        lastReadMessageId = lastReadMessageId,
+    )
+}

--- a/app/src/test/java/timur/gilfanov/messenger/domain/entity/chat/validation/ChatValidatorTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/entity/chat/validation/ChatValidatorTest.kt
@@ -25,7 +25,7 @@ import timur.gilfanov.messenger.domain.entity.message.MessageId
 
 class ChatValidatorTest {
 
-    private val validator = ChatValidator()
+    private val validator = ChatValidatorImpl()
 
     @Test
     fun validateValidParticipants() {

--- a/app/src/test/java/timur/gilfanov/messenger/domain/entity/message/MessageBuilder.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/entity/message/MessageBuilder.kt
@@ -1,0 +1,42 @@
+package timur.gilfanov.messenger.domain.entity.message
+
+import java.util.UUID
+import kotlinx.datetime.Instant
+import timur.gilfanov.messenger.domain.entity.ResultWithError
+import timur.gilfanov.messenger.domain.entity.ResultWithError.Success
+import timur.gilfanov.messenger.domain.entity.chat.ChatId
+import timur.gilfanov.messenger.domain.entity.chat.Participant
+import timur.gilfanov.messenger.domain.usecase.ValidationError
+
+fun buildMessage(builder: MessageBuilder.() -> Unit): Message =
+    MessageBuilder().apply(builder).build()
+
+class MessageBuilder {
+    var id: MessageId = MessageId(UUID.randomUUID())
+    var parentId: MessageId? = null
+    var sender: Participant? = null
+    var recipient: ChatId = ChatId(UUID.randomUUID())
+    var createdAt: Instant? = null
+    var sentAt: Instant? = null
+    var deliveredAt: Instant? = null
+    var editedAt: Instant? = null
+    var deliveryStatus: DeliveryStatus? = null
+    var validationResult: ResultWithError<Unit, ValidationError> = Success(Unit)
+
+    fun build(): Message {
+        requireNotNull(sender) { "Sender must be specified" }
+        requireNotNull(createdAt) { "CreatedAt must be specified" }
+        return object : Message {
+            override val id: MessageId = this@MessageBuilder.id
+            override val parentId: MessageId? = this@MessageBuilder.parentId
+            override val sender: Participant = this@MessageBuilder.sender!!
+            override val recipient: ChatId = this@MessageBuilder.recipient
+            override val createdAt: Instant = this@MessageBuilder.createdAt!!
+            override val sentAt: Instant? = this@MessageBuilder.sentAt
+            override val deliveredAt: Instant? = this@MessageBuilder.deliveredAt
+            override val editedAt: Instant? = this@MessageBuilder.editedAt
+            override val deliveryStatus: DeliveryStatus? = this@MessageBuilder.deliveryStatus
+            override fun validate(): ResultWithError<Unit, ValidationError> = validationResult
+        }
+    }
+}

--- a/app/src/test/java/timur/gilfanov/messenger/domain/entity/message/TextMessageBuilder.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/entity/message/TextMessageBuilder.kt
@@ -1,0 +1,43 @@
+package timur.gilfanov.messenger.domain.entity.message
+
+import java.util.UUID
+import kotlinx.datetime.Instant
+import timur.gilfanov.messenger.domain.entity.chat.ChatId
+import timur.gilfanov.messenger.domain.entity.chat.Participant
+import timur.gilfanov.messenger.domain.entity.message.validation.TextValidatorVersion
+
+fun buildTextMessage(builder: TextMessageBuilder.() -> Unit): TextMessage =
+    TextMessageBuilder().apply(builder).build()
+
+class TextMessageBuilder {
+    var id: MessageId = MessageId(UUID.randomUUID())
+    var parentId: MessageId? = null
+    var sender: Participant? = null
+    var recipient: ChatId = ChatId(UUID.randomUUID())
+    var createdAt: Instant? = null
+    var sentAt: Instant? = null
+    var deliveredAt: Instant? = null
+    var editedAt: Instant? = null
+    var text: String = ""
+    var deliveryStatus: DeliveryStatus? = null
+    var textValidatorVersion: TextValidatorVersion = TextValidatorVersion.Current
+
+    fun build(): TextMessage {
+        requireNotNull(sender) { "Sender must be specified" }
+        requireNotNull(createdAt) { "CreatedAt must be specified" }
+
+        return TextMessage(
+            id = id,
+            parentId = parentId,
+            sender = sender!!,
+            recipient = recipient,
+            createdAt = createdAt!!,
+            sentAt = sentAt,
+            deliveredAt = deliveredAt,
+            editedAt = editedAt,
+            text = text,
+            deliveryStatus = deliveryStatus,
+            textValidatorVersion = textValidatorVersion,
+        )
+    }
+}

--- a/app/src/test/java/timur/gilfanov/messenger/domain/entity/message/validation/DeliveryStatusValidatorTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/entity/message/validation/DeliveryStatusValidatorTest.kt
@@ -20,7 +20,7 @@ import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusV
 
 class DeliveryStatusValidatorTest {
 
-    private val validator = DeliveryStatusValidator()
+    private val validator = DeliveryStatusValidatorImpl()
 
     @Test
     fun validateNullToSendingTransition() {

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/ChatMessageIntegrationTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/ChatMessageIntegrationTest.kt
@@ -16,12 +16,14 @@ import timur.gilfanov.messenger.domain.entity.chat.Chat
 import timur.gilfanov.messenger.domain.entity.chat.ChatId
 import timur.gilfanov.messenger.domain.entity.chat.Participant
 import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
+import timur.gilfanov.messenger.domain.entity.chat.buildChat
 import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidationError
 import timur.gilfanov.messenger.domain.entity.chat.validation.ChatValidator
 import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus
 import timur.gilfanov.messenger.domain.entity.message.Message
 import timur.gilfanov.messenger.domain.entity.message.MessageId
 import timur.gilfanov.messenger.domain.entity.message.TextMessage
+import timur.gilfanov.messenger.domain.entity.message.buildTextMessage
 import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidationError
 import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidator
 
@@ -45,19 +47,19 @@ class ChatMessageIntegrationTest {
         val chatId = ChatId(UUID.randomUUID())
         val participant = createParticipant(customTime)
 
-        val initialChat = createChat(
-            id = chatId,
-            participant = participant,
-        )
+        val initialChat = buildChat {
+            id = chatId
+            participants = persistentSetOf(participant)
+        }
 
         val messageId = MessageId(UUID.randomUUID())
-        val message = createMessage(
-            id = messageId,
-            text = "Hello, this is a test message",
-            sender = participant,
-            recipient = chatId,
-            createdAt = customTime,
-        )
+        val message = buildTextMessage {
+            id = messageId
+            text = "Hello, this is a test message"
+            sender = participant
+            recipient = chatId
+            createdAt = customTime
+        }
 
         val updatedMessage = message.copy(deliveryStatus = DeliveryStatus.Sent)
         val updatedChat = initialChat.copy(
@@ -114,39 +116,5 @@ class ChatMessageIntegrationTest {
         name = "Test User",
         pictureUrl = null,
         joinedAt = customTime,
-    )
-
-    private fun createChat(
-        id: ChatId = ChatId(UUID.randomUUID()),
-        name: String = "Test Chat",
-        participant: Participant,
-        messages: kotlinx.collections.immutable.ImmutableList<Message> = persistentListOf(),
-        unreadMessagesCount: Int = 0,
-    ): Chat = Chat(
-        id = id,
-        name = name,
-        pictureUrl = null,
-        messages = messages,
-        participants = persistentSetOf(participant),
-        rules = persistentSetOf(),
-        unreadMessagesCount = unreadMessagesCount,
-        lastReadMessageId = null,
-    )
-
-    private fun createMessage(
-        id: MessageId = MessageId(UUID.randomUUID()),
-        text: String = "Test message",
-        sender: Participant,
-        recipient: ChatId,
-        createdAt: Instant,
-        deliveryStatus: DeliveryStatus? = null,
-    ): TextMessage = TextMessage(
-        id = id,
-        parentId = null,
-        text = text,
-        sender = sender,
-        recipient = recipient,
-        createdAt = createdAt,
-        deliveryStatus = deliveryStatus,
     )
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,7 +1,4 @@
 complexity:
-  LongMethod:
-    ignoreAnnotated:
-      - Test
   TooManyFunctions:
     ignoreAnnotatedFunctions: [ 'Preview' ]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ composeRules = "0.4.22"
 kover = "0.9.1"
 kotlinxDatetime = "0.5.0"
 kotlinxCollectionsImmutable = "0.3.7"
-mockk = "1.13.10"
 turbine = "1.1.0"
 
 [libraries]
@@ -40,7 +39,6 @@ ktlint-compose = { module = "io.nlopez.compose.rules:ktlint", version.ref = "com
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
-mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]


### PR DESCRIPTION
### Summary

This pull request refactors unit tests by introducing builder and fake classes for `Chat`, `Message`, and `DeliveryStatusValidator`. The changes remove extensive mock usage, improving test readability and maintainability. It also includes a Detekt configuration update to clean up test annotations.