### PR TITLE
Implement FlowChatList error handling

### DIFF
--- a/app/src/main/java/timur/gilfanov/messenger/domain/usecase/participant/ParticipantRepository.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/usecase/participant/ParticipantRepository.kt
@@ -6,6 +6,7 @@ import timur.gilfanov.messenger.domain.entity.chat.Chat
 import timur.gilfanov.messenger.domain.entity.chat.ChatId
 import timur.gilfanov.messenger.domain.entity.message.Message
 import timur.gilfanov.messenger.domain.entity.message.MessageId
+import timur.gilfanov.messenger.domain.usecase.participant.chat.FlowChatListError
 import timur.gilfanov.messenger.domain.usecase.participant.chat.ReceiveChatUpdatesError
 import timur.gilfanov.messenger.domain.usecase.participant.chat.RepositoryJoinChatError
 import timur.gilfanov.messenger.domain.usecase.participant.chat.RepositoryLeaveChatError
@@ -15,7 +16,7 @@ import timur.gilfanov.messenger.domain.usecase.participant.message.RepositoryDel
 interface ParticipantRepository {
     suspend fun sendMessage(message: Message): Flow<Message>
     suspend fun editMessage(message: Message): Flow<Message>
-    suspend fun flowChatList(): Flow<List<Chat>>
+    suspend fun flowChatList(): Flow<ResultWithError<List<Chat>, FlowChatListError>>
     suspend fun deleteMessage(
         messageId: MessageId,
         mode: DeleteMessageMode,

--- a/app/src/main/java/timur/gilfanov/messenger/domain/usecase/participant/chat/FlowChatListError.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/usecase/participant/chat/FlowChatListError.kt
@@ -1,0 +1,8 @@
+package timur.gilfanov.messenger.domain.usecase.participant.chat
+
+sealed class FlowChatListError {
+    object NetworkNotAvailable : FlowChatListError()
+    object RemoteUnreachable : FlowChatListError()
+    object RemoteError : FlowChatListError()
+    object LocalError : FlowChatListError()
+}

--- a/app/src/main/java/timur/gilfanov/messenger/domain/usecase/participant/chat/FlowChatListUseCase.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/usecase/participant/chat/FlowChatListUseCase.kt
@@ -1,9 +1,12 @@
 package timur.gilfanov.messenger.domain.usecase.participant.chat
 
 import kotlinx.coroutines.flow.Flow
+import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.chat.Chat
 import timur.gilfanov.messenger.domain.usecase.participant.ParticipantRepository
+import timur.gilfanov.messenger.domain.usecase.participant.chat.FlowChatListError
 
 class FlowChatListUseCase(private val repository: ParticipantRepository) {
-    suspend operator fun invoke(): Flow<List<Chat>> = repository.flowChatList()
+    suspend operator fun invoke(): Flow<ResultWithError<List<Chat>, FlowChatListError>> =
+        repository.flowChatList()
 }

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/ParticipantRepositoryNotImplemented.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/ParticipantRepositoryNotImplemented.kt
@@ -1,13 +1,18 @@
 package timur.gilfanov.messenger.domain.usecase.participant
 
+import kotlinx.coroutines.flow.Flow
+import timur.gilfanov.messenger.domain.entity.ResultWithError
+import timur.gilfanov.messenger.domain.entity.chat.Chat
 import timur.gilfanov.messenger.domain.entity.chat.ChatId
 import timur.gilfanov.messenger.domain.entity.message.Message
 import timur.gilfanov.messenger.domain.entity.message.MessageId
+import timur.gilfanov.messenger.domain.usecase.participant.chat.FlowChatListError
 import timur.gilfanov.messenger.domain.usecase.participant.message.DeleteMessageMode
 
 class ParticipantRepositoryNotImplemented : ParticipantRepository {
     override suspend fun leaveChat(chatId: ChatId) = error("Not implemented in delegate")
-    override suspend fun flowChatList() = error("Not implemented in delegate")
+    override suspend fun flowChatList(): Flow<ResultWithError<List<Chat>, FlowChatListError>> =
+        error("Not implemented in delegate")
     override suspend fun deleteMessage(messageId: MessageId, mode: DeleteMessageMode) =
         error("Not implemented in delegate")
     override suspend fun editMessage(message: Message) = error("Not implemented in delegate")

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/chat/FlowChatListUseCaseTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/chat/FlowChatListUseCaseTest.kt
@@ -1,22 +1,26 @@
 package timur.gilfanov.messenger.domain.usecase.participant.chat
 
 import app.cash.turbine.test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import kotlin.test.assertEquals
+import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.chat.Chat
 import timur.gilfanov.messenger.domain.entity.chat.buildChat
 import timur.gilfanov.messenger.domain.usecase.participant.ParticipantRepository
 import timur.gilfanov.messenger.domain.usecase.participant.ParticipantRepositoryNotImplemented
+import timur.gilfanov.messenger.domain.usecase.participant.chat.FlowChatListError
 
 class FlowChatListUseCaseTest {
 
     private class RepositoryFake(
-        val chatListFlow: Flow<List<Chat>>,
+        val chatListFlow: Flow<ResultWithError<List<Chat>, FlowChatListError>>,
     ) : ParticipantRepository by ParticipantRepositoryNotImplemented() {
-        override suspend fun flowChatList(): Flow<List<Chat>> = chatListFlow
+        override suspend fun flowChatList(): Flow<ResultWithError<List<Chat>, FlowChatListError>> =
+            chatListFlow
     }
 
     @Test
@@ -33,8 +37,13 @@ class FlowChatListUseCaseTest {
         val useCase = FlowChatListUseCase(repository)
 
         useCase().test {
-            assertEquals(listOf(chat1), awaitItem())
-            assertEquals(listOf(chat1, chat2), awaitItem())
+            val first = awaitItem()
+            assertIs<ResultWithError.Success<List<Chat>, FlowChatListError>>(first)
+            assertEquals(listOf(chat1), first.data)
+
+            val second = awaitItem()
+            assertIs<ResultWithError.Success<List<Chat>, FlowChatListError>>(second)
+            assertEquals(listOf(chat1, chat2), second.data)
             awaitComplete()
         }
     }

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/repository/RepositoryFake.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/repository/RepositoryFake.kt
@@ -19,6 +19,7 @@ import timur.gilfanov.messenger.domain.entity.message.MessageId
 import timur.gilfanov.messenger.domain.entity.message.TextMessage
 import timur.gilfanov.messenger.domain.usecase.participant.ParticipantRepository
 import timur.gilfanov.messenger.domain.usecase.participant.ParticipantRepositoryNotImplemented
+import timur.gilfanov.messenger.domain.usecase.participant.chat.FlowChatListError
 import timur.gilfanov.messenger.domain.usecase.participant.chat.ReceiveChatUpdatesError
 import timur.gilfanov.messenger.domain.usecase.participant.chat.RepositoryJoinChatError
 import timur.gilfanov.messenger.domain.usecase.participant.chat.RepositoryLeaveChatError
@@ -50,8 +51,11 @@ class RepositoryFake :
         chatListFlow.emit(chats.values.toList())
     }
 
-    override suspend fun flowChatList(): Flow<List<Chat>> =
-        chatListFlow.onStart { emit(chats.values.toList()) }.distinctUntilChanged()
+    override suspend fun flowChatList(): Flow<ResultWithError<List<Chat>, FlowChatListError>> =
+        chatListFlow
+            .onStart { emit(chats.values.toList()) }
+            .distinctUntilChanged()
+            .map { ResultWithError.Success<List<Chat>, FlowChatListError>(it) }
 
     override suspend fun createChat(chat: Chat): ResultWithError<Chat, RepositoryCreateChatError> {
         chats[chat.id] = chat

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/repository/RepositoryFakeTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/repository/RepositoryFakeTest.kt
@@ -18,6 +18,7 @@ import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus
 import timur.gilfanov.messenger.domain.entity.message.Message
 import timur.gilfanov.messenger.domain.entity.message.MessageId
 import timur.gilfanov.messenger.domain.entity.message.TextMessage
+import timur.gilfanov.messenger.domain.usecase.participant.chat.FlowChatListError
 import timur.gilfanov.messenger.domain.usecase.participant.chat.ReceiveChatUpdatesError
 
 class RepositoryFakeTest {
@@ -42,12 +43,16 @@ class RepositoryFakeTest {
         repository.createChat(chat1)
 
         repository.flowChatList().test {
-            assertEquals(listOf(chat1), awaitItem())
+            val initial = awaitItem()
+            assertIs<Success<List<Chat>, FlowChatListError>>(initial)
+            assertEquals(listOf(chat1), initial.data)
 
             val chat2 = chat1.copy(id = ChatId(UUID.randomUUID()), name = "Chat 2")
             repository.createChat(chat2)
 
-            assertEquals(listOf(chat1, chat2), awaitItem())
+            val second = awaitItem()
+            assertIs<Success<List<Chat>, FlowChatListError>>(second)
+            assertEquals(listOf(chat1, chat2), second.data)
 
             cancelAndIgnoreRemainingEvents()
         }


### PR DESCRIPTION
## Summary
- add `FlowChatListError` sealed class for repository errors
- update `ParticipantRepository` and `FlowChatListUseCase` to return `ResultWithError`
- adjust repository fakes and tests for new API

## Testing
- `./gradlew ktlintFormat` *(passed)*
- `./gradlew test detekt ktlintCheck` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432193821c8331a5330955d90a2577