### PR TITLE
Remove the `carryforward: true` setting for `unit`, `component`, and `application` tests

### DIFF
--- a/Testing Strategy.md
+++ b/Testing Strategy.md
@@ -35,14 +35,14 @@ Tests of all categories can be executed sequentially.
 
 ## Test Triggers Matrix
 
-| Category          | Environment (where)                   | Trigger (when) |
-|-------------------|---------------------------------------|----------------|
-| Architecture      | Local                                 | Every commit   |
-| Unit              | Local                                 | Every commit   |
-| Component         | Local                                 | Every commit   |
-| Feature           | Local, emulators                      | Pre-merge      |
-| Application       | Local, emulators, 1 phone, 1 foldable | Post-merge     |
-| Release Candidate | 8 phones, 1 foldable, 1 tablet        | Pre-release    |
+| Category          | Environment (where)                   | Trigger (when)        |
+|-------------------|---------------------------------------|-----------------------|
+| Architecture      | Local                                 | Every commit          |
+| Unit              | Local                                 | Every commit          |
+| Component         | Local                                 | Every commit          |
+| Feature           | Local, emulators                      | Pre-merge             |
+| Application       | Local, emulators, 1 phone, 1 foldable | Pre-merge, Post-merge |
+| Release Candidate | 8 phones, 1 foldable, 1 tablet        | Pre-release           |
 
 
 ## Device Coverage Strategy

--- a/app/src/androidTest/java/timur/gilfanov/messenger/feature/chat/ChatMessageSendingFeatureTest.kt
+++ b/app/src/androidTest/java/timur/gilfanov/messenger/feature/chat/ChatMessageSendingFeatureTest.kt
@@ -29,7 +29,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import timur.gilfanov.annotations.ApplicationTest
 import timur.gilfanov.annotations.FeatureTest
 import timur.gilfanov.annotations.ReleaseCandidateTest
 import timur.gilfanov.messenger.ChatScreenTestActivity

--- a/app/src/androidTest/java/timur/gilfanov/messenger/feature/chatlist/ChatListEmptyFeatureTest.kt
+++ b/app/src/androidTest/java/timur/gilfanov/messenger/feature/chatlist/ChatListEmptyFeatureTest.kt
@@ -66,6 +66,7 @@ class ChatListEmptyFeatureTest {
             onNodeWithTag("new_chat_button").assertExists()
 
             activity.requestedOrientation = SCREEN_ORIENTATION_LANDSCAPE
+            waitForIdle()
 
             onNodeWithTag("search_button").assertExists()
             onNodeWithTag("new_chat_button").assertExists()

--- a/app/src/androidTest/java/timur/gilfanov/messenger/feature/chatlist/ChatListNotEmptyFeatureTest.kt
+++ b/app/src/androidTest/java/timur/gilfanov/messenger/feature/chatlist/ChatListNotEmptyFeatureTest.kt
@@ -19,7 +19,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import timur.gilfanov.annotations.ApplicationTest
 import timur.gilfanov.annotations.FeatureTest
 import timur.gilfanov.messenger.ChatListScreenTestActivity
 import timur.gilfanov.messenger.data.repository.WithChatsParticipantRepository
@@ -69,6 +68,7 @@ class ChatListNotEmptyFeatureTest {
             waitUntilExactlyOneExists(hasTestTag("chat_item_550e8400-e29b-41d4-a716-446655440002"))
 
             activity.requestedOrientation = SCREEN_ORIENTATION_LANDSCAPE
+            waitForIdle()
 
             onNodeWithTag("search_button").assertExists()
             onNodeWithTag("new_chat_button").assertExists()
@@ -87,6 +87,8 @@ class ChatListNotEmptyFeatureTest {
                 } else {
                     SCREEN_ORIENTATION_PORTRAIT
                 }
+                waitForIdle()
+
                 onNodeWithTag("chat_list").assertExists()
                 onNodeWithTag("chat_item_550e8400-e29b-41d4-a716-446655440002").assertExists()
             }

--- a/codecov.yml
+++ b/codecov.yml
@@ -74,14 +74,12 @@ flag_management:
   individual_flags:
     
     - name: unit
-      carryforward: true
       statuses:
         - type: project
           target: 80%
           threshold: 1%
     
     - name: component
-      carryforward: true
       statuses:
         - type: project
           target: 70%
@@ -95,7 +93,6 @@ flag_management:
           threshold: 1%
     
     - name: application
-      carryforward: true
       statuses:
         - type: project
           target: 40%


### PR DESCRIPTION
This commit removes the `carryforward: true` setting for `unit`, `component`, and `application` flags in the `codecov.yml` configuration. This change ensures that coverage reports for these flags are based solely on the current commit's test results, rather than carrying forward coverage from previous commits.

Additionally, it updates the testing strategy to include "Application" category tests in the "Pre-merge" trigger.