### PR TITLE
Standardize test fixture and builder naming conventions

### DIFF
--- a/app/src/test/java/timur/gilfanov/messenger/data/repository/MessengerRepositoryIntegrationTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/data/repository/MessengerRepositoryIntegrationTest.kt
@@ -22,7 +22,6 @@ import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
-import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -64,6 +63,7 @@ import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
 import timur.gilfanov.messenger.domain.entity.message.Message
 import timur.gilfanov.messenger.domain.entity.message.MessageId
 import timur.gilfanov.messenger.domain.entity.message.TextMessage
+import timur.gilfanov.messenger.domain.testutil.DomainTestFixtures
 import timur.gilfanov.messenger.domain.usecase.chat.RepositoryCreateChatError
 import timur.gilfanov.messenger.domain.usecase.chat.RepositoryJoinChatError
 import timur.gilfanov.messenger.domain.usecase.message.DeleteMessageMode
@@ -546,33 +546,25 @@ class MessengerRepositoryIntegrationTest {
     }
 
     // Helper functions
-    private fun createTestChat(): Chat = Chat(
+    private fun createTestChat(): Chat = DomainTestFixtures.createTestChat(
         id = testChatId,
-        participants = persistentSetOf(createTestParticipant()),
         name = "Test Chat",
-        pictureUrl = null,
-        rules = persistentSetOf(),
-        unreadMessagesCount = 0,
-        lastReadMessageId = null,
-        messages = kotlinx.collections.immutable.persistentListOf(),
+        participants = setOf(createTestParticipant()),
     )
 
-    private fun createTestParticipant(): Participant = Participant(
+    private fun createTestParticipant(): Participant = DomainTestFixtures.createTestParticipant(
         id = testParticipantId,
         name = "Test User",
-        pictureUrl = null,
         joinedAt = testTimestamp,
         onlineAt = testTimestamp,
     )
 
-    private fun createTestMessage(): TextMessage = TextMessage(
+    private fun createTestMessage(): TextMessage = DomainTestFixtures.createTestTextMessage(
         id = testMessageId,
         text = "Test message",
-        parentId = null,
         sender = createTestParticipant(),
         recipient = testChatId,
         createdAt = testTimestamp,
-        deliveryStatus = null,
     )
 
     private fun setupRepository(scope: CoroutineScope, mockEngine: MockEngine) {

--- a/app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImplTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImplTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
@@ -21,8 +20,8 @@ import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.chat.Chat
 import timur.gilfanov.messenger.domain.entity.chat.ChatId
 import timur.gilfanov.messenger.domain.entity.chat.ChatPreview
-import timur.gilfanov.messenger.domain.entity.chat.Participant
 import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
+import timur.gilfanov.messenger.domain.testutil.DomainTestFixtures
 import timur.gilfanov.messenger.testutil.InMemoryDatabaseRule
 import timur.gilfanov.messenger.util.NoOpLogger
 
@@ -270,33 +269,22 @@ class LocalChatDataSourceImplTest {
     private fun createTestChat(
         id: String = "66666666-6666-6666-6666-666666666666", // Fixed UUID
         name: String = "Test Chat",
-    ) = Chat(
+    ) = DomainTestFixtures.createTestChat(
         id = ChatId(UUID.fromString(id)),
         name = name,
-        participants = persistentSetOf(
-            Participant(
+        participants = setOf(
+            DomainTestFixtures.createTestParticipant(
                 id = ParticipantId(UUID.fromString("44444444-4444-4444-4444-444444444444")),
                 name = "User 1",
-                pictureUrl = null,
                 joinedAt = Instant.fromEpochMilliseconds(1000000),
                 onlineAt = null,
-                isAdmin = false,
-                isModerator = false,
             ),
-            Participant(
+            DomainTestFixtures.createTestParticipant(
                 id = ParticipantId(UUID.fromString("55555555-5555-5555-5555-555555555555")),
                 name = "User 2",
-                pictureUrl = null,
                 joinedAt = Instant.fromEpochMilliseconds(1100000),
                 onlineAt = null,
-                isAdmin = true,
-                isModerator = false,
             ),
         ),
-        pictureUrl = null,
-        messages = persistentListOf(),
-        rules = persistentSetOf(),
-        unreadMessagesCount = 0,
-        lastReadMessageId = null,
     )
 }

--- a/app/src/test/java/timur/gilfanov/messenger/domain/testutil/DomainTestFixtures.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/testutil/DomainTestFixtures.kt
@@ -1,0 +1,173 @@
+package timur.gilfanov.messenger.domain.testutil
+
+import java.util.UUID
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.datetime.Instant
+import timur.gilfanov.messenger.domain.entity.chat.Chat
+import timur.gilfanov.messenger.domain.entity.chat.ChatId
+import timur.gilfanov.messenger.domain.entity.chat.Participant
+import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
+import timur.gilfanov.messenger.domain.entity.chat.buildChat
+import timur.gilfanov.messenger.domain.entity.chat.buildParticipant
+import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus
+import timur.gilfanov.messenger.domain.entity.message.Message
+import timur.gilfanov.messenger.domain.entity.message.MessageId
+import timur.gilfanov.messenger.domain.entity.message.TextMessage
+import timur.gilfanov.messenger.domain.entity.message.buildTextMessage
+
+object DomainTestFixtures {
+
+    data class TestChatParams(
+        val id: ChatId = ChatId(UUID.randomUUID()),
+        val name: String = "Test Chat",
+        val participants: Set<Participant> = setOf(),
+        val messages: List<Message> = emptyList(),
+        val isOneToOne: Boolean = false,
+        val pictureUrl: String? = null,
+        val unreadMessagesCount: Int = 0,
+        val lastReadMessageId: MessageId? = null,
+    )
+
+    fun createTestChat(params: TestChatParams): Chat = buildChat {
+        this.id = params.id
+        this.name = params.name
+        this.participants = if (params.participants.isEmpty()) {
+            persistentSetOf<Participant>().add(createTestParticipant())
+        } else {
+            persistentSetOf<Participant>().addAll(params.participants)
+        }
+        this.messages = persistentListOf<Message>().addAll(params.messages)
+        this.isOneToOne = params.isOneToOne
+        this.pictureUrl = params.pictureUrl
+        this.unreadMessagesCount = params.unreadMessagesCount
+        this.lastReadMessageId = params.lastReadMessageId
+        this.rules = persistentSetOf()
+    }
+
+    fun createTestParticipant(
+        id: ParticipantId = ParticipantId(UUID.randomUUID()),
+        name: String = "Test User",
+        pictureUrl: String? = null,
+        joinedAt: Instant = Instant.fromEpochMilliseconds(1000),
+        onlineAt: Instant? = Instant.fromEpochMilliseconds(1000),
+    ): Participant = buildParticipant {
+        this.id = id
+        this.name = name
+        this.pictureUrl = pictureUrl
+        this.joinedAt = joinedAt
+        this.onlineAt = onlineAt
+    }
+
+    data class TestMessageParams(
+        val id: MessageId = MessageId(UUID.randomUUID()),
+        val text: String = "Test message",
+        val sender: Participant = createTestParticipant(),
+        val recipient: ChatId = ChatId(UUID.randomUUID()),
+        val deliveryStatus: DeliveryStatus = DeliveryStatus.Sent,
+        val createdAt: Instant = Instant.fromEpochMilliseconds(2000),
+        val parentId: MessageId? = null,
+    )
+
+    fun createTestTextMessage(params: TestMessageParams): TextMessage = buildTextMessage {
+        this.id = params.id
+        this.text = params.text
+        this.sender = params.sender
+        this.recipient = params.recipient
+        this.deliveryStatus = params.deliveryStatus
+        this.createdAt = params.createdAt
+        this.parentId = params.parentId
+    }
+
+    data class TestChatWithParticipantsParams(
+        val chatId: ChatId = ChatId(UUID.randomUUID()),
+        val currentUserId: ParticipantId = ParticipantId(UUID.randomUUID()),
+        val otherUserIds: List<ParticipantId> = listOf(ParticipantId(UUID.randomUUID())),
+        val messages: List<Message> = emptyList(),
+        val isOneToOne: Boolean = true,
+        val chatName: String = "Direct Message",
+    )
+
+    fun createTestChatWithParticipants(params: TestChatWithParticipantsParams): Chat {
+        val currentUser = createTestParticipant(id = params.currentUserId, name = "Current User")
+        val otherUsers = if (params.otherUserIds.size == 1) {
+            listOf(
+                createTestParticipant(
+                    id = params.otherUserIds[0],
+                    name = "Other User",
+                    onlineAt = null,
+                ),
+            )
+        } else {
+            params.otherUserIds.mapIndexed { index, userId ->
+                createTestParticipant(id = userId, name = "User ${index + 1}", onlineAt = null)
+            }
+        }
+
+        return createTestChat(
+            TestChatParams(
+                id = params.chatId,
+                name = params.chatName,
+                participants = setOf(currentUser) + otherUsers,
+                messages = params.messages,
+                isOneToOne = params.isOneToOne,
+            ),
+        )
+    }
+
+    // Convenience overloads for backward compatibility
+    @Suppress("LongParameterList")
+    fun createTestChat(
+        id: ChatId = ChatId(UUID.randomUUID()),
+        name: String = "Test Chat",
+        participants: Set<Participant> = setOf(),
+        messages: List<Message> = emptyList(),
+        isOneToOne: Boolean = false,
+        pictureUrl: String? = null,
+        unreadMessagesCount: Int = 0,
+        lastReadMessageId: MessageId? = null,
+    ): Chat = createTestChat(
+        TestChatParams(
+            id,
+            name,
+            participants,
+            messages,
+            isOneToOne,
+            pictureUrl,
+            unreadMessagesCount,
+            lastReadMessageId,
+        ),
+    )
+
+    @Suppress("LongParameterList")
+    fun createTestTextMessage(
+        id: MessageId = MessageId(UUID.randomUUID()),
+        text: String = "Test message",
+        sender: Participant = createTestParticipant(),
+        recipient: ChatId = ChatId(UUID.randomUUID()),
+        deliveryStatus: DeliveryStatus = DeliveryStatus.Sent,
+        createdAt: Instant = Instant.fromEpochMilliseconds(2000),
+        parentId: MessageId? = null,
+    ): TextMessage = createTestTextMessage(
+        TestMessageParams(id, text, sender, recipient, deliveryStatus, createdAt, parentId),
+    )
+
+    @Suppress("LongParameterList")
+    fun createTestChatWithParticipants(
+        chatId: ChatId = ChatId(UUID.randomUUID()),
+        currentUserId: ParticipantId = ParticipantId(UUID.randomUUID()),
+        otherUserIds: List<ParticipantId> = listOf(ParticipantId(UUID.randomUUID())),
+        messages: List<Message> = emptyList(),
+        isOneToOne: Boolean = otherUserIds.size == 1,
+        chatName: String = if (isOneToOne) "Direct Message" else "Group Chat",
+    ): Chat = createTestChatWithParticipants(
+        TestChatWithParticipantsParams(
+            chatId,
+            currentUserId,
+            otherUserIds,
+            messages,
+            isOneToOne,
+            chatName,
+        ),
+    )
+}

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt
@@ -28,7 +28,7 @@ import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesError.Chat
 import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.RepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestMessage
 
@@ -46,7 +46,7 @@ class ChatViewModelErrorHandlingTest {
 
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Failure(ChatNotFound))
-        val repository = RepositoryFake(flowChat = chatFlow)
+        val repository = ChatRepositoryFake(flowChat = chatFlow)
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 
@@ -79,7 +79,7 @@ class ChatViewModelErrorHandlingTest {
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Success(initialChat))
 
-        val repository = RepositoryFake(flowChat = chatFlow)
+        val repository = ChatRepositoryFake(flowChat = chatFlow)
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 
@@ -132,7 +132,7 @@ class ChatViewModelErrorHandlingTest {
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(
                 Failure(ReceiveChatUpdatesError.NetworkNotAvailable),
             )
-        val repository = RepositoryFake(flowChat = chatFlow)
+        val repository = ChatRepositoryFake(flowChat = chatFlow)
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 
@@ -166,7 +166,7 @@ class ChatViewModelErrorHandlingTest {
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Success(initialChat))
 
-        val repository = RepositoryFake(flowChat = chatFlow)
+        val repository = ChatRepositoryFake(flowChat = chatFlow)
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelLoadingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelLoadingTest.kt
@@ -26,7 +26,7 @@ import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesError.Netw
 import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.RepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestMessage
 
@@ -47,7 +47,7 @@ class ChatViewModelLoadingTest {
         val message = createTestMessage(currentUserId, "Hello!", joinedAt = now, createdAt = now)
         val chat = createTestChat(chatId, currentUserId, otherUserId, listOf(message))
 
-        val repository = RepositoryFake(chat = chat, flowChat = flowOf(Success(chat)))
+        val repository = ChatRepositoryFake(chat = chat, flowChat = flowOf(Success(chat)))
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 
@@ -109,7 +109,7 @@ class ChatViewModelLoadingTest {
 
         val chat = createTestChat(chatId, currentUserId, otherUserId, isOneToOne = false)
 
-        val repository = RepositoryFake(
+        val repository = ChatRepositoryFake(
             chat = chat,
             flowChat = flowOf(Success(chat)),
         )
@@ -163,7 +163,7 @@ class ChatViewModelLoadingTest {
         val chatId = ChatId(UUID.randomUUID())
         val currentUserId = ParticipantId(UUID.randomUUID())
 
-        val repository = RepositoryFake(
+        val repository = ChatRepositoryFake(
             flowChat = flowOf(Failure(NetworkNotAvailable)),
         )
 

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelMessageSendingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelMessageSendingTest.kt
@@ -33,8 +33,8 @@ import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageError
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.RepositoryFake
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.RepositoryFakeWithStatusFlow
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFakeWithStatusFlow
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
@@ -54,7 +54,8 @@ class ChatViewModelMessageSendingTest {
         ).forEach { statuses ->
             val chatId = ChatId(UUID.randomUUID())
             val currentUserId = ParticipantId(UUID.randomUUID())
-            val chat = createTestChat(chatId, currentUserId)
+            val otherUserId = ParticipantId(UUID.randomUUID())
+            val chat = createTestChat(chatId, currentUserId, otherUserId)
             val now = Instant.fromEpochMilliseconds(1000)
             val message = buildTextMessage {
                 sender = chat.participants.first { it.id == currentUserId }
@@ -62,7 +63,7 @@ class ChatViewModelMessageSendingTest {
                 this.createdAt = now
                 text = "Test message"
             }
-            val rep = RepositoryFakeWithStatusFlow(chat, statuses)
+            val rep = ChatRepositoryFakeWithStatusFlow(chat, statuses)
             val viewModel = ChatViewModel(
                 chatIdUuid = chatId.id,
                 currentUserIdUuid = currentUserId.id,
@@ -110,9 +111,10 @@ class ChatViewModelMessageSendingTest {
     fun `dismissDialogError clears error`() = runTest {
         val chatId = ChatId(UUID.randomUUID())
         val currentUserId = ParticipantId(UUID.randomUUID())
+        val otherUserId = ParticipantId(UUID.randomUUID())
 
-        val chat = createTestChat(chatId, currentUserId)
-        val repository = RepositoryFake(chat = chat)
+        val chat = createTestChat(chatId, currentUserId, otherUserId)
+        val repository = ChatRepositoryFake(chat = chat)
 
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTextInputTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTextInputTest.kt
@@ -21,7 +21,7 @@ import timur.gilfanov.messenger.domain.entity.message.validation.TextValidationE
 import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.RepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -39,7 +39,7 @@ class ChatViewModelTextInputTest {
 
         val initialChat = createTestChat(chatId, currentUserId, otherUserId)
 
-        val repository = RepositoryFake(chat = initialChat, flowSendMessage = flowOf())
+        val repository = ChatRepositoryFake(chat = initialChat, flowSendMessage = flowOf())
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt
@@ -28,7 +28,7 @@ import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesError
 import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.RepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestMessage
 
@@ -52,7 +52,7 @@ class ChatViewModelUpdatesTest {
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Success(initialChat))
 
-        val repository = RepositoryFake(flowChat = chatFlow)
+        val repository = ChatRepositoryFake(flowChat = chatFlow)
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 
@@ -110,7 +110,7 @@ class ChatViewModelUpdatesTest {
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Success(initialChat))
 
-        val repository = RepositoryFake(flowChat = chatFlow)
+        val repository = ChatRepositoryFake(flowChat = chatFlow)
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 
@@ -178,7 +178,7 @@ class ChatViewModelUpdatesTest {
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Success(initialChat))
 
-        val repository = RepositoryFake(flowChat = chatFlow)
+        val repository = ChatRepositoryFake(flowChat = chatFlow)
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListUiStateUnitTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListUiStateUnitTest.kt
@@ -4,20 +4,18 @@ import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.junit.Test
 import org.junit.experimental.categories.Category
+import timur.gilfanov.annotations.Unit
 import timur.gilfanov.messenger.domain.entity.chat.ChatId
 import timur.gilfanov.messenger.domain.entity.chat.Participant
 import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
-import timur.gilfanov.messenger.domain.entity.chat.buildChat
-import timur.gilfanov.messenger.domain.entity.chat.buildParticipant
 import timur.gilfanov.messenger.domain.entity.message.Message
-import timur.gilfanov.messenger.domain.entity.message.buildTextMessage
+import timur.gilfanov.messenger.domain.testutil.DomainTestFixtures
 
-@Category(timur.gilfanov.annotations.Unit::class)
+@Category(Unit::class)
 class ChatListUiStateUnitTest {
 
     private val testChatId = ChatId(UUID.randomUUID())
@@ -29,22 +27,22 @@ class ChatListUiStateUnitTest {
         id: ParticipantId = testUserId,
         name: String = "Test User",
         onlineAt: Instant? = null,
-    ) = buildParticipant {
-        this.id = id
-        this.name = name
-        this.joinedAt = testTimestamp
-        this.onlineAt = onlineAt
-    }
+    ) = DomainTestFixtures.createTestParticipant(
+        id = id,
+        name = name,
+        joinedAt = testTimestamp,
+        onlineAt = onlineAt,
+    )
 
     private fun createTestTextMessage(
         text: String = "Test message",
         senderId: ParticipantId = testUserId,
         createdAt: Instant = testTimestamp,
-    ) = buildTextMessage {
-        this.sender = createTestParticipant(senderId)
-        this.text = text
-        this.createdAt = createdAt
-    }
+    ) = DomainTestFixtures.createTestTextMessage(
+        text = text,
+        sender = createTestParticipant(senderId),
+        createdAt = createdAt,
+    )
 
     private data class TestChatParams(
         val id: ChatId = ChatId(UUID.randomUUID()),
@@ -56,15 +54,16 @@ class ChatListUiStateUnitTest {
         val unreadMessagesCount: Int = 0,
     )
 
-    private fun createTestChat(params: TestChatParams = TestChatParams()) = buildChat {
-        this.id = params.id
-        this.name = params.name
-        this.pictureUrl = params.pictureUrl
-        this.messages = persistentListOf<Message>().addAll(params.messages)
-        this.participants = persistentSetOf<Participant>().addAll(params.participants)
-        this.isOneToOne = params.isOneToOne
-        this.unreadMessagesCount = params.unreadMessagesCount
-    }
+    private fun createTestChat(params: TestChatParams = TestChatParams()) =
+        DomainTestFixtures.createTestChat(
+            id = params.id,
+            name = params.name,
+            pictureUrl = params.pictureUrl,
+            messages = params.messages,
+            participants = params.participants.toSet(),
+            isOneToOne = params.isOneToOne,
+            unreadMessagesCount = params.unreadMessagesCount,
+        )
 
     @Test
     fun `toChatListItemUiModel maps basic chat properties correctly`() {


### PR DESCRIPTION
- Create shared DomainTestFixtures with standardized createTest* factory functions
- Rename test doubles for clarity: RepositoryFake → ChatRepositoryFake
- Consolidate duplicate test helpers across MessengerRepositoryIntegrationTest, LocalChatDataSourceImplTest, and ChatListUiStateUnitTest
- Replace 12+ duplicate helper functions with centralized fixtures for better maintainability
- Use parameter objects pattern to avoid LongParameterList violations while maintaining backward compatibility
- Update 9 test files to use consistent naming and shared utilities
- Fix compilation errors in ChatViewModelMessageSendingTest missing otherUserId parameter
- Add missing unreadMessagesCount and lastReadMessageId fields to DomainTestFixtures
- Fix participant naming in createTestChatWithParticipants to match expected test behavior ("Other User" for single participants)

🤖 Generated with [Claude Code](https://claude.ai/code)