### PR TITLE
Rename ChatRepositoryFake to MessengerRepositoryFake for clarity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  build-mock:
     permissions:
       contents: read
       checks: write # required for mikepenz/action-junit-report
@@ -91,7 +91,7 @@ jobs:
           report_paths: app/build/test-results/testMockDebugUnitTest/*.xml
           check_name: "Architecture Test Results"
 
-      - name: Build Debug and AndroidTest APKs
+      - name: Build Mock Debug and AndroidTest APKs
         run: ./gradlew -Pcoverage assembleMockDebug assembleMockDebugAndroidTest
 
       - name: Upload Debug APK
@@ -112,8 +112,107 @@ jobs:
           name: kotlin-classfiles
           path: app/build/tmp/kotlin-classes/mockDebug
 
+  build-production:
+    permissions:
+      contents: read
+      checks: write # required for mikepenz/action-junit-report
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Secret Scanning
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: .
+          base: ${{ github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event.pull_request.head.sha || github.sha }}
+          extra_args: --results=verified,unknown
+
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.gradle/configuration-cache
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run Lint
+        run: ./gradlew lintProductionRelease &> lint.log
+        
+      - name: Run Detekt
+        id: detekt
+        run: ./gradlew detekt
+        continue-on-error: true
+
+      - name: Upload Lint Log
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-lint-log
+          path: lint.log
+
+      - name: Upload Detekt Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-detekt-report
+          path: app/build/reports/detekt/detekt.html
+          
+      - name: Fail if Detekt found issues
+        if: steps.detekt.outcome != 'success'
+        run: |
+          echo "Detekt found issues. See the uploaded report for details."
+          exit 1
+
+      - name: Run Architecture Tests
+        run: ./gradlew testProductionReleaseUnitTest -PtestCategory=timur.gilfanov.annotations.Architecture
+
+      - name: Upload Architecture Test Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-architecture-test-report
+          path: app/build/reports/tests/testProductionReleaseUnitTest
+
+      - name: Publish Architecture Test Results
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: app/build/test-results/testProductionReleaseUnitTest/*.xml
+          check_name: "Production Architecture Test Results"
+
+      - name: Build Production Release and AndroidTest APKs
+        run: ./gradlew -Pcoverage assembleProductionRelease assembleProductionReleaseAndroidTest
+
+      - name: Upload Production Release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-release-apk
+          path: app/build/outputs/apk/production/release/app-production-release.apk
+
+      - name: Upload Production Release AndroidTest APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-release-androidtest-apk
+          path: app/build/outputs/apk/androidTest/production/release/app-production-release-androidTest.apk
+
+      - name: Upload Production Release Kotlin class files
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-release-classfiles
+          path: app/build/tmp/kotlin-classes/productionRelease
+
   unit-component-tests:
-    needs: build
+    needs: build-mock
 
     permissions:
       checks: write # required for mikepenz/action-junit-report
@@ -242,7 +341,7 @@ jobs:
 
   feature-tests:
     if: github.event_name == 'pull_request'
-    needs: build
+    needs: build-mock
 
     permissions:
       checks: write # required for mikepenz/action-junit-report
@@ -452,7 +551,7 @@ jobs:
 
   application-tests-emulator:
     if: github.event_name == 'pull_request'
-    needs: build
+    needs: build-mock
 
     permissions:
       checks: write # required for mikepenz/action-junit-report
@@ -614,7 +713,7 @@ jobs:
 
   application-tests-devices:
     if: github.ref == 'refs/heads/main'
-    needs: build
+    needs: build-mock
 
     permissions:
       checks: write # required for mikepenz/action-junit-report
@@ -730,7 +829,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: kotlin-classfiles
-          path: app/build/tmp/kotlin-classes/debug
+          path: app/build/tmp/kotlin-classes/mockDebug
 
       - name: Generate Device-Specific Coverage Reports
         run: |
@@ -819,7 +918,7 @@ jobs:
 
   release-candidate-tests:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: build
+    needs: build-production
 
     permissions:
       checks: write # required for mikepenz/action-junit-report
@@ -844,8 +943,17 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build Release APKs
-        run: ./gradlew assembleRelease assembleReleaseAndroidTest
+      - name: Download Production Release APK
+        uses: actions/download-artifact@v4
+        with:
+          name: production-release-apk
+          path: app/build/outputs/apk/production/release
+
+      - name: Download Production Release AndroidTest APK
+        uses: actions/download-artifact@v4
+        with:
+          name: production-release-androidtest-apk
+          path: app/build/outputs/apk/androidTest/production/release
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -861,8 +969,8 @@ jobs:
         run: |
           gcloud firebase test android run \
             --type instrumentation \
-            --app app/build/outputs/apk/release/app-release.apk \
-            --test app/build/outputs/apk/androidTest/release/app-release-androidTest.apk \
+            --app app/build/outputs/apk/production/release/app-production-release.apk \
+            --test app/build/outputs/apk/androidTest/production/release/app-production-release-androidTest.apk \
             --device model=MediumPhone.arm,version=30 \
             --device model=MediumPhone.arm,version=33 \
             --device model=MediumPhone.arm,version=31 \
@@ -925,11 +1033,11 @@ jobs:
           report_paths: release-testlab-results/**/*.xml
           check_name: "Release Candidate Test Results"
 
-      - name: Download Kotlin class files
+      - name: Download Production Release Kotlin class files
         uses: actions/download-artifact@v4
         with:
-          name: kotlin-classfiles
-          path: app/build/tmp/kotlin-classes/debug
+          name: production-release-classfiles
+          path: app/build/tmp/kotlin-classes/productionRelease
 
       - name: Generate Release Candidate Device-Specific Coverage Reports
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,8 @@ jobs:
           path: app/build/tmp/kotlin-classes/mockDebug
 
   build-production:
+    if: startsWith(github.ref, 'refs/tags/v')
+
     permissions:
       contents: read
       checks: write # required for mikepenz/action-junit-report

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatPaginationIntegrationTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatPaginationIntegrationTest.kt
@@ -29,7 +29,7 @@ import timur.gilfanov.messenger.domain.usecase.message.MessageRepository
 import timur.gilfanov.messenger.domain.usecase.message.RepositoryDeleteMessageError
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 
 /**
@@ -53,7 +53,7 @@ class ChatPaginationIntegrationTest {
         val otherUserId = ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
 
         val chat = createTestChat(chatId, currentUserId, otherUserId)
-        val chatRepository = ChatRepositoryFake(chat = chat)
+        val chatRepository = MessengerRepositoryFake(chat = chat)
         val messageRepository = PaginationTestRepository()
 
         val viewModel = ChatViewModel(
@@ -101,7 +101,7 @@ class ChatPaginationIntegrationTest {
         }
 
         val chat = createTestChat(chatId, currentUserId, otherUserId)
-        val chatRepository = ChatRepositoryFake(chat = chat)
+        val chatRepository = MessengerRepositoryFake(chat = chat)
         val messageRepository = PaginationTestRepository(testMessages = testMessages)
 
         val viewModel = ChatViewModel(
@@ -137,7 +137,7 @@ class ChatPaginationIntegrationTest {
         val otherUserId = ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
 
         val chat = createTestChat(chatId, currentUserId, otherUserId)
-        val chatRepository = ChatRepositoryFake(chat = chat)
+        val chatRepository = MessengerRepositoryFake(chat = chat)
         val messageRepository = PaginationTestRepository(testMessages = emptyList())
 
         val viewModel = ChatViewModel(
@@ -186,7 +186,7 @@ class ChatPaginationIntegrationTest {
         )
 
         val chat = createTestChat(chatId, currentUserId, otherUserId)
-        val chatRepository = ChatRepositoryFake(chat = chat)
+        val chatRepository = MessengerRepositoryFake(chat = chat)
         val messageRepository = PaginationTestRepository(testMessages = paginatedMessages)
 
         val viewModel = ChatViewModel(

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt
@@ -29,8 +29,8 @@ import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFakeWithPaging
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestMessage
 
@@ -48,7 +48,7 @@ class ChatViewModelErrorHandlingTest {
 
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Failure(ChatNotFound))
-        val repository = ChatRepositoryFake(flowChat = chatFlow)
+        val repository = MessengerRepositoryFake(flowChat = chatFlow)
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 
@@ -132,7 +132,7 @@ class ChatViewModelErrorHandlingTest {
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(
                 Failure(ReceiveChatUpdatesError.NetworkNotAvailable),
             )
-        val repository = ChatRepositoryFake(flowChat = chatFlow)
+        val repository = MessengerRepositoryFake(flowChat = chatFlow)
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 
@@ -168,7 +168,7 @@ class ChatViewModelErrorHandlingTest {
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Success(initialChat))
 
-        val repository = ChatRepositoryFake(flowChat = chatFlow)
+        val repository = MessengerRepositoryFake(flowChat = chatFlow)
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt
@@ -29,8 +29,8 @@ import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFakeWithPaging
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFakeWithPaging
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestMessage
 
@@ -83,7 +83,7 @@ class ChatViewModelErrorHandlingTest {
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Success(initialChat))
 
-        val repository = ChatRepositoryFakeWithPaging(
+        val repository = MessengerRepositoryFakeWithPaging(
             initialChat = initialChat,
             chatFlow = chatFlow,
         )

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelLoadingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelLoadingTest.kt
@@ -27,7 +27,7 @@ import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestMessage
 
@@ -81,7 +81,7 @@ class ChatViewModelLoadingTest {
         val message = createTestMessage(currentUserId, "Hello!", joinedAt = now, createdAt = now)
         val chat = createTestChat(chatId, currentUserId, otherUserId, listOf(message))
 
-        val repository = ChatRepositoryFake(chat = chat, flowChat = flowOf(Success(chat)))
+        val repository = MessengerRepositoryFake(chat = chat, flowChat = flowOf(Success(chat)))
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 
@@ -124,7 +124,7 @@ class ChatViewModelLoadingTest {
 
         val chat = createTestChat(chatId, currentUserId, otherUserId, isOneToOne = false)
 
-        val repository = ChatRepositoryFake(
+        val repository = MessengerRepositoryFake(
             chat = chat,
             flowChat = flowOf(Success(chat)),
         )
@@ -168,7 +168,7 @@ class ChatViewModelLoadingTest {
         val chatId = ChatId(UUID.randomUUID())
         val currentUserId = ParticipantId(UUID.randomUUID())
 
-        val repository = ChatRepositoryFake(
+        val repository = MessengerRepositoryFake(
             flowChat = flowOf(Failure(NetworkNotAvailable)),
         )
 

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelMessageSendingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelMessageSendingTest.kt
@@ -30,8 +30,8 @@ import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageError
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFake
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFakeWithStatusFlow
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFakeWithStatusFlow
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
@@ -42,7 +42,6 @@ class ChatViewModelMessageSendingTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test
-    @Suppress("LongMethod")
     fun `sending a message clears input only once`() = runTest {
         listOf(
             listOf(Sending(0), Sending(50)),
@@ -61,7 +60,7 @@ class ChatViewModelMessageSendingTest {
                 this.createdAt = now
                 text = "Test message"
             }
-            val rep = ChatRepositoryFakeWithStatusFlow(chat, statuses)
+            val rep = MessengerRepositoryFakeWithStatusFlow(chat, statuses)
             val getPagedMessagesUseCase = GetPagedMessagesUseCase(rep)
             val viewModel = ChatViewModel(
                 chatIdUuid = chatId.id,
@@ -109,7 +108,7 @@ class ChatViewModelMessageSendingTest {
         val otherUserId = ParticipantId(UUID.randomUUID())
 
         val chat = createTestChat(chatId, currentUserId, otherUserId)
-        val repository = ChatRepositoryFake(chat = chat)
+        val repository = MessengerRepositoryFake(chat = chat)
 
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
@@ -68,7 +68,7 @@ object ChatViewModelTestFixtures {
         )
     }
 
-    class ChatRepositoryFake(
+    class MessengerRepositoryFake(
         private val chat: Chat? = null,
         private val flowChat: Flow<ResultWithError<Chat, ReceiveChatUpdatesError>>? = null,
         private val flowSendMessage: Flow<Message>? = null,
@@ -114,7 +114,7 @@ object ChatViewModelTestFixtures {
             pagedMessages?.let { flowOf(PagingData.from(it)) } ?: flowOf(PagingData.empty())
     }
 
-    class ChatRepositoryFakeWithStatusFlow(chat: Chat, val statuses: List<DeliveryStatus>) :
+    class MessengerRepositoryFakeWithStatusFlow(chat: Chat, val statuses: List<DeliveryStatus>) :
         ChatRepository,
         MessageRepository {
 

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
@@ -178,7 +178,7 @@ object ChatViewModelTestFixtures {
      * automatically emits the messages from that chat as PagingData.
      * This ensures pagination stays in sync with chat updates during tests.
      */
-    class ChatRepositoryFakeWithPaging(
+    class MessengerRepositoryFakeWithPaging(
         private val initialChat: Chat? = null,
         private val chatFlow: Flow<ResultWithError<Chat, ReceiveChatUpdatesError>>? = null,
     ) : ChatRepository,

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTextInputTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTextInputTest.kt
@@ -22,7 +22,7 @@ import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -40,7 +40,7 @@ class ChatViewModelTextInputTest {
 
         val initialChat = createTestChat(chatId, currentUserId, otherUserId)
 
-        val repository = ChatRepositoryFake(chat = initialChat, flowSendMessage = flowOf())
+        val repository = MessengerRepositoryFake(chat = initialChat, flowSendMessage = flowOf())
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt
@@ -30,7 +30,7 @@ import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFakeWithPaging
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFakeWithPaging
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestMessage
 
@@ -55,7 +55,7 @@ class ChatViewModelUpdatesTest {
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Success(initialChat))
 
-        val repository = ChatRepositoryFakeWithPaging(
+        val repository = MessengerRepositoryFakeWithPaging(
             initialChat = initialChat,
             chatFlow = chatFlow,
         )
@@ -190,7 +190,7 @@ class ChatViewModelUpdatesTest {
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Success(initialChat))
 
-        val repository = ChatRepositoryFakeWithPaging(
+        val repository = MessengerRepositoryFakeWithPaging(
             initialChat = initialChat,
             chatFlow = chatFlow,
         )

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt
@@ -29,7 +29,7 @@ import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
-import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.ChatRepositoryFakeWithPaging
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestMessage
@@ -119,7 +119,7 @@ class ChatViewModelUpdatesTest {
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesError>>(Success(initialChat))
 
-        val repository = ChatRepositoryFake(flowChat = chatFlow)
+        val repository = MessengerRepositoryFake(flowChat = chatFlow)
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
 


### PR DESCRIPTION
The original name was misleading as the class implements both ChatRepository and MessageRepository interfaces. The new name better reflects its unified responsibility and aligns with the MessengerRepositoryImpl naming pattern.

🤖 Generated with [Claude Code](https://claude.ai/code)