### PR TITLE
Add screenshot testing to Testing Strategy and README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,17 +138,40 @@ sequenceDiagram
 - **DI**: Hilt 2.57
 - **Database**: Room 2.7.2
 - **Networking**: Ktor 3.2.3
-- **Testing**: JUnit4, Turbine, Robolectric
+- **Testing**: JUnit4, Turbine, Robolectric, Roborazzi
 - **Code Quality**: Detekt, Ktlint, Konsist
 
 ## 📊 Testing Strategy
 
-Comprehensive testing pyramid with 5 test categories. See [Testing Strategy](https://github.com/timurgilfanov/messenger/blob/main/docs/Testing%20Strategy.md) for details.
+Comprehensive testing pyramid with 6 test categories. See [Testing Strategy](https://github.com/timurgilfanov/messenger/blob/main/docs/Testing%20Strategy.md) for details.
 
 | Category     | Coverage Target   | Execution            |
 |--------------|-------------------|----------------------|
 | Architecture | Rules enforcement | Every commit         |
 | Unit         | 80%+              | Every commit         |
 | Component    | 70%+              | Every commit         |
+| Screenshot   | All UI components | Pre-merge            |
 | Feature      | 50%+              | Pre-merge            |
 | Application  | 40%+              | Pre-merge/Post-merge |
+
+### 📸 Screenshot Testing
+
+Visual regression testing for UI components using **Roborazzi + Robolectric**:
+
+```bash
+# Verify screenshots match baselines
+./gradlew verifyRoborazziMockDebug
+
+# Update screenshot baselines  
+./gradlew recordRoborazziMockDebug
+
+# Check screenshot directory size (50MB limit)
+./gradlew checkScreenshotSize
+```
+
+**CI Integration:**
+- PRs automatically verify screenshots and upload diffs as artifacts
+- Apply `update-screenshots` label to auto-update baselines in PR branch
+- Size limit enforced via `./gradlew preCommit`
+
+See [Screenshot Testing docs](docs/Screenshot%20Testing.md) for details.

--- a/docs/Screenshot Testing.md
+++ b/docs/Screenshot Testing.md
@@ -6,6 +6,7 @@
 Local commands
 - Verify screenshots: `./gradlew verifyRoborazziMockDebug`
 - Record/update baselines: `./gradlew recordRoborazziMockDebug`
+- Check directory size: `./gradlew checkScreenshotSize`
 
 CI workflows
 - PR verification: job `screenshot-tests` calls reusable workflow `.github/workflows/screenshots-verify.yml` (verify only) and uploads artifacts named `roborazzi-screenshots` on diffs.

--- a/docs/Testing Strategy.md
+++ b/docs/Testing Strategy.md
@@ -10,6 +10,8 @@ To balance between short time to find bug and waiting time for tests to run I ne
 
 **Component** — test multiply classes together. Example: button behaviour or appearance, form validation. 
 
+**Screenshot** — verify UI component visual appearance and prevent unintended visual regressions. Example: message bubble appearance, dark theme rendering, error states display.
+
 **Feature** — test integration between two or more components. Example: UI or ViewModel send a message to use case and handle different responses.
 
 **Application** — test deployable binary to verify application functionality. Example: pressing chat preview on chat's list shows selected chat.
@@ -25,6 +27,7 @@ Test classes should be annotated with it's test category, so CI/CD could know wh
 | Architecture      | N/A                | No                                      | Local                                             | N/A                                     | Debuggable             | Every commit                     |
 | Unit              | Fakes              | No                                      | Local                                             | N/A                                     | Debuggable             | Every commit                     | 
 | Component         | Fakes              | No                                      | Local <br/> Robolectric                           | N/A                                     | Debuggable             | Every commit                     |
+| Screenshot        | Fakes              | No                                      | Local <br/> Robolectric                           | N/A                                     | Debuggable             | Pre-merge                        |
 | Feature           | Real, in-memory DB | Mocked                                  | Local <br/> Robolectric <br/> Emulator            | N/A                                     | Debuggable             | Pre-merge                        |
 | Application       | Real, in-memory DB | Mocked <br/> **Staging** <br/> **Prod** | Emulator <br/> **1 phone, 1 foldable**            | Latest 2 major                          | Debuggable             | Pre-merge <br/> **Post-merge**   |
 | Release Candidate | Real               | Prod                                    | Emulator <br/> **4 phones, 1 foldable, 1 tablet** | Latest 4 major versions + older popular | Minified release build | Post-merge <br/> **Pre-release** |
@@ -33,6 +36,7 @@ Test classes should be annotated with it's test category, so CI/CD could know wh
 
 * Unit: 80%
 * Component: 70%
+* Screenshot: All UI components
 * Feature: 50%
 * Application: 40%
 * Release Candidate: 30%
@@ -40,6 +44,7 @@ Test classes should be annotated with it's test category, so CI/CD could know wh
 ## Execution Rime:
 * Unit, Architecture: < 100ms per test
 * Component: < 1 second per test
+* Screenshot: < 2 seconds per test
 * Feature: < 5 seconds per test
 * Application: < 30 seconds per test
 * Release Candidate: < 5 minutes per critical journey
@@ -48,6 +53,7 @@ Test classes should be annotated with it's test category, so CI/CD could know wh
 ### Pre-merge
 * Static analysis passes 100%
 * Unit and Component coverage > 80% for new code
+* Screenshot tests pass with no visual regressions
 * Enforce test pyramid ratio with significant tolerance
 
 ### Pre-release


### PR DESCRIPTION
- Add Screenshot as new test category in Testing Strategy with execution matrix
- Update README with dedicated screenshot testing section and commands
- Include Roborazzi in tech stack and update test category count to 6
- Add checkScreenshotSize command to Screenshot Testing docs
- Target all UI components coverage with pre-merge execution lifecycle

🤖 Generated with [Claude Code](https://claude.ai/code)