### PR TITLE
Chore: Remove unused toUseCaseError methods from message use cases

### DIFF
--- a/app/src/main/java/timur/gilfanov/messenger/domain/usecase/message/DeleteMessageUseCase.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/usecase/message/DeleteMessageUseCase.kt
@@ -24,7 +24,6 @@ import timur.gilfanov.messenger.domain.usecase.message.DeleteMessageError.Messag
 import timur.gilfanov.messenger.domain.usecase.message.DeleteMessageError.MessageNotFound
 import timur.gilfanov.messenger.domain.usecase.message.DeleteMessageError.NotAuthorized
 import timur.gilfanov.messenger.domain.usecase.message.DeleteMessageMode.FOR_SENDER_ONLY
-import timur.gilfanov.messenger.domain.usecase.message.repository.DeleteMessageRepositoryError
 
 class DeleteMessageUseCase(val repository: MessageRepository) {
 
@@ -55,14 +54,6 @@ class DeleteMessageUseCase(val repository: MessageRepository) {
                 is Failure -> Failure(result.error.toUseCaseError())
             }
         }
-    }
-
-    private fun DeleteMessageRepositoryError.toUseCaseError(): DeleteMessageError = when (this) {
-        is DeleteMessageRepositoryError.MessageNotFound -> MessageNotFound
-        is DeleteMessageRepositoryError.LocalOperationFailed ->
-            DeleteMessageError.LocalOperationFailed(error)
-        is DeleteMessageRepositoryError.RemoteOperationFailed ->
-            DeleteMessageError.RemoteOperationFailed(error)
     }
 
     private fun checkRules(

--- a/app/src/main/java/timur/gilfanov/messenger/domain/usecase/message/EditMessageUseCase.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/usecase/message/EditMessageUseCase.kt
@@ -23,7 +23,6 @@ import timur.gilfanov.messenger.domain.usecase.message.EditMessageError.EditWind
 import timur.gilfanov.messenger.domain.usecase.message.EditMessageError.MessageIsNotValid
 import timur.gilfanov.messenger.domain.usecase.message.EditMessageError.RecipientChanged
 import timur.gilfanov.messenger.domain.usecase.message.EditMessageError.SenderIdChanged
-import timur.gilfanov.messenger.domain.usecase.message.repository.EditMessageRepositoryError
 
 class EditMessageUseCase(
     val repository: MessageRepository,
@@ -68,13 +67,6 @@ class EditMessageUseCase(
                 }
             }
         }
-
-    private fun EditMessageRepositoryError.toUseCaseError(): EditMessageError = when (this) {
-        is EditMessageRepositoryError.LocalOperationFailed ->
-            EditMessageError.LocalOperationFailed(error)
-        is EditMessageRepositoryError.RemoteOperationFailed ->
-            EditMessageError.RemoteOperationFailed(error)
-    }
 
     fun checkRules(
         chat: Chat,


### PR DESCRIPTION
## Summary

- Removes unused `toUseCaseError()` private methods from `DeleteMessageUseCase` and `EditMessageUseCase`
- These methods became redundant after error mapping was moved to extension functions in the previous PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)