### PR TITLE
fix: Remove redundant `isRefreshing` state updates in `ChatListViewModel`

### DIFF
--- a/app/src/main/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListViewModel.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListViewModel.kt
@@ -110,7 +110,6 @@ class ChatListViewModel @Inject constructor(
                                     state.copy(
                                         uiState = uiState,
                                         isLoading = false,
-                                        isRefreshing = false,
                                         error = null,
                                     )
                                 }
@@ -118,7 +117,6 @@ class ChatListViewModel @Inject constructor(
                                 is ResultWithError.Failure -> {
                                     state.copy(
                                         isLoading = false,
-                                        isRefreshing = false,
                                         error = result.error,
                                     )
                                 }


### PR DESCRIPTION
Both `observeChatList` and `observeChatListUpdating` modify `isRefreshing` field:
* `observeChatListUpdating` sets it based on repository status
* `observeChatList` sets it to false on completion.

Only `observeChatListUpdating` should control refresh state.

Closes #174

### Follow-up issues
- #184 