### PR TITLE
refactor: Rename chat list update state to `isChatListUpdateApplying`

### DIFF
--- a/app/src/androidTest/java/timur/gilfanov/messenger/test/AndroidTestRepositoryWithRealImplementation.kt
+++ b/app/src/androidTest/java/timur/gilfanov/messenger/test/AndroidTestRepositoryWithRealImplementation.kt
@@ -189,7 +189,8 @@ class AndroidTestRepositoryWithRealImplementation(
         > =
         realRepository.flowChatList()
 
-    override fun isChatListUpdating(): Flow<Boolean> = realRepository.isChatListUpdating()
+    override fun isChatListUpdateApplying(): Flow<Boolean> =
+        realRepository.isChatListUpdateApplying()
 
     override suspend fun receiveChatUpdates(
         chatId: ChatId,

--- a/app/src/androidTest/java/timur/gilfanov/messenger/test/ChatRepositoryStub.kt
+++ b/app/src/androidTest/java/timur/gilfanov/messenger/test/ChatRepositoryStub.kt
@@ -40,7 +40,7 @@ class ChatRepositoryStub : ChatRepository {
         > =
         flowOf(ResultWithError.Success(emptyList()))
 
-    override fun isChatListUpdating(): Flow<Boolean> = flowOf(false)
+    override fun isChatListUpdateApplying(): Flow<Boolean> = flowOf(false)
 
     override suspend fun receiveChatUpdates(
         chatId: ChatId,

--- a/app/src/main/java/timur/gilfanov/messenger/data/repository/MessengerRepositoryImpl.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/data/repository/MessengerRepositoryImpl.kt
@@ -77,7 +77,7 @@ import timur.gilfanov.messenger.util.Logger
  *
  *                     // Process chat changes (this repository's responsibility)
  *                     if (delta.chatChanges.isNotEmpty()) {
- *                         isUpdatingFlow.value = true
+ *                         isChatListUpdateApplying.value = true
  *                         localDataSources.sync.applyChatListDelta(
  *                             ChatListDelta(
  *                                 changes = delta.chatChanges,
@@ -85,7 +85,7 @@ import timur.gilfanov.messenger.util.Logger
  *                                 hasMoreChanges = delta.hasMoreChanges
  *                             )
  *                         )
- *                         isUpdatingFlow.value = false
+ *                         isChatListUpdateApplying.value = false
  *                     }
  *
  *                     // Note: settingsChange filtered out (SettingsRepository handles it)
@@ -126,7 +126,7 @@ class MessengerRepositoryImpl @Inject constructor(
         private const val TAG = "MessengerRepository"
     }
 
-    private val isUpdatingFlow = MutableStateFlow(false)
+    private val isChatListUpdateApplying = MutableStateFlow(false)
 
     init {
         performDeltaSyncLoop(backgroundScope)
@@ -148,9 +148,9 @@ class MessengerRepositoryImpl @Inject constructor(
                 .onEach { deltaResult ->
                     if (deltaResult is ResultWithError.Success) {
                         logger.d(TAG, "Received delta updates: ${deltaResult.data}")
-                        isUpdatingFlow.value = true
+                        isChatListUpdateApplying.value = true
                         localDataSources.sync.applyChatListDelta(deltaResult.data)
-                        isUpdatingFlow.value = false
+                        isChatListUpdateApplying.value = false
                     } else {
                         logger.w(TAG, "Delta result was failure: $deltaResult")
                     }
@@ -244,7 +244,7 @@ class MessengerRepositoryImpl @Inject constructor(
             }
         }
 
-    override fun isChatListUpdating(): Flow<Boolean> = isUpdatingFlow
+    override fun isChatListUpdateApplying(): Flow<Boolean> = isChatListUpdateApplying
 
     override suspend fun receiveChatUpdates(
         chatId: ChatId,

--- a/app/src/main/java/timur/gilfanov/messenger/domain/usecase/chat/ChatRepository.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/domain/usecase/chat/ChatRepository.kt
@@ -41,7 +41,7 @@ interface ChatRepository {
         ResultWithError<List<ChatPreview>, FlowChatListRepositoryError>,
         >
 
-    fun isChatListUpdating(): Flow<Boolean>
+    fun isChatListUpdateApplying(): Flow<Boolean>
 
     suspend fun receiveChatUpdates(
         chatId: ChatId,

--- a/app/src/main/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListScreen.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListScreen.kt
@@ -267,7 +267,7 @@ private fun ChatListScreenEmptyPreview() {
                     pictureUrl = null,
                 ),
                 isLoading = false,
-                isRefreshing = false,
+                isChatListUpdateApplying = false,
                 error = null,
             ),
             actions = ChatListContentActions(
@@ -293,7 +293,7 @@ private fun ChatListScreenEmptyPortraitPreview() {
                     pictureUrl = null,
                 ),
                 isLoading = false,
-                isRefreshing = false,
+                isChatListUpdateApplying = false,
                 error = null,
             ),
             actions = ChatListContentActions(
@@ -352,7 +352,7 @@ private fun ChatListScreenWithChatsPreview() {
                     pictureUrl = null,
                 ),
                 isLoading = false,
-                isRefreshing = false,
+                isChatListUpdateApplying = false,
                 error = null,
             ),
             actions = ChatListContentActions(
@@ -378,7 +378,7 @@ private fun ChatListScreenLoadingPreview() {
                     pictureUrl = null,
                 ),
                 isLoading = true,
-                isRefreshing = false,
+                isChatListUpdateApplying = false,
                 error = null,
             ),
             actions = ChatListContentActions(
@@ -404,7 +404,7 @@ private fun ChatListScreenErrorPreview() {
                     pictureUrl = null,
                 ),
                 isLoading = false,
-                isRefreshing = false,
+                isChatListUpdateApplying = false,
                 error = FlowChatListRepositoryError.LocalOperationFailed(
                     LocalStorageError.Corrupted,
                 ),

--- a/app/src/main/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListUiState.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListUiState.kt
@@ -33,7 +33,7 @@ data class ChatListScreenState(
     val currentUser: CurrentUserUiModel =
         CurrentUserUiModel(ParticipantId(java.util.UUID.randomUUID()), "", null),
     val isLoading: Boolean = false,
-    val isRefreshing: Boolean = false,
+    val isChatListUpdateApplying: Boolean = false,
     val error: FlowChatListRepositoryError? = null,
 )
 

--- a/app/src/main/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListViewModel.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListViewModel.kt
@@ -70,14 +70,14 @@ class ChatListViewModel @Inject constructor(
     @OptIn(OrbitExperimental::class, FlowPreview::class)
     private suspend fun observeChatListUpdating() = subIntent {
         repeatOnSubscription {
-            chatRepository.isChatListUpdating()
+            chatRepository.isChatListUpdateApplying()
                 .distinctUntilChanged()
                 .debounce(UPDATING_DEBOUNCE)
                 .collect { isUpdating ->
                     ensureActive()
                     withContext(Dispatchers.Main) {
                         reduce {
-                            state.copy(isRefreshing = isUpdating)
+                            state.copy(isChatListUpdateApplying = isUpdating)
                         }
                     }
                 }

--- a/app/src/test/java/timur/gilfanov/messenger/data/repository/MessengerRepositoryImplTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/data/repository/MessengerRepositoryImplTest.kt
@@ -198,7 +198,7 @@ class MessengerRepositoryImplTest {
     }
 
     @Test
-    fun `isChatListUpdating initially returns false`() = runTest {
+    fun `isChatListUpdateApplying initially returns false`() = runTest {
         repository = repositoryImpl(backgroundScope)
         repository.flowChatList().test {
             val initialResult = awaitItem()
@@ -207,7 +207,7 @@ class MessengerRepositoryImplTest {
             )
             assertEquals(0, initialResult.data.size)
 
-            repository.isChatListUpdating().test {
+            repository.isChatListUpdateApplying().test {
                 assertEquals(false, awaitItem())
             }
         }
@@ -471,7 +471,7 @@ class MessengerRepositoryImplTest {
     }
 
     @Test
-    fun `isChatListUpdating should change to true when delta sync occurs`() = runTest {
+    fun `isChatListUpdateApplying should change to true when delta sync occurs`() = runTest {
         // Given: Repository is created with empty state
         repository = repositoryImpl(backgroundScope)
 
@@ -485,7 +485,7 @@ class MessengerRepositoryImplTest {
             val chatListTestScope = this
 
             // When & Then: Test updating state changes during sync
-            repository.isChatListUpdating().test {
+            repository.isChatListUpdateApplying().test {
                 assertEquals(false, awaitItem())
 
                 // Add chat to remote to trigger delta sync

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/chat/FlowChatListUseCaseTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/chat/FlowChatListUseCaseTest.kt
@@ -35,7 +35,7 @@ class FlowChatListUseCaseTest {
             chatListFlow
 
         // Implement other required ChatRepository methods as not implemented for this test
-        override fun isChatListUpdating() = flowOf(false)
+        override fun isChatListUpdateApplying() = flowOf(false)
         override suspend fun createChat(chat: Chat) = error("Not implemented")
         override suspend fun deleteChat(chatId: ChatId) = error("Not implemented")
         override suspend fun joinChat(chatId: ChatId, inviteLink: String?) =

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/chat/JoinChatUseCaseTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/chat/JoinChatUseCaseTest.kt
@@ -49,7 +49,7 @@ class JoinChatUseCaseTest {
 
         // Implement other required ChatRepository methods as not implemented for this test
         override suspend fun flowChatList() = error("Not implemented")
-        override fun isChatListUpdating() = kotlinx.coroutines.flow.flowOf(false)
+        override fun isChatListUpdateApplying() = kotlinx.coroutines.flow.flowOf(false)
         override suspend fun createChat(chat: Chat) = error("Not implemented")
         override suspend fun deleteChat(chatId: ChatId) = error("Not implemented")
         override suspend fun leaveChat(chatId: ChatId) = error("Not implemented")

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/chat/LeaveChatUseCaseTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/chat/LeaveChatUseCaseTest.kt
@@ -33,7 +33,7 @@ class LeaveChatUseCaseTest {
 
         // Implement other required ChatRepository methods as not implemented for this test
         override suspend fun flowChatList() = error("Not implemented")
-        override fun isChatListUpdating() = kotlinx.coroutines.flow.flowOf(false)
+        override fun isChatListUpdateApplying() = kotlinx.coroutines.flow.flowOf(false)
         override suspend fun createChat(chat: timur.gilfanov.messenger.domain.entity.chat.Chat) =
             error("Not implemented")
         override suspend fun deleteChat(chatId: ChatId) = error("Not implemented")

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/chat/ReceiveChatUpdatesUseCaseTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/participant/chat/ReceiveChatUpdatesUseCaseTest.kt
@@ -34,7 +34,7 @@ class ReceiveChatUpdatesUseCaseTest {
 
         // Implement other required ChatRepository methods as not implemented for this test
         override suspend fun flowChatList() = error("Not implemented")
-        override fun isChatListUpdating() = kotlinx.coroutines.flow.flowOf(false)
+        override fun isChatListUpdateApplying() = kotlinx.coroutines.flow.flowOf(false)
         override suspend fun createChat(chat: Chat) = error("Not implemented")
         override suspend fun deleteChat(chatId: ChatId) = error("Not implemented")
         override suspend fun joinChat(chatId: ChatId, inviteLink: String?) =

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/privileged/CreateChatUseCaseTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/privileged/CreateChatUseCaseTest.kt
@@ -46,7 +46,7 @@ class CreateChatUseCaseTest {
 
         // Implement other required ChatRepository methods as not implemented for this test
         override suspend fun flowChatList() = error("Not implemented")
-        override fun isChatListUpdating() = kotlinx.coroutines.flow.flowOf(false)
+        override fun isChatListUpdateApplying() = kotlinx.coroutines.flow.flowOf(false)
         override suspend fun deleteChat(chatId: ChatId) = error("Not implemented")
         override suspend fun joinChat(chatId: ChatId, inviteLink: String?) =
             error("Not implemented")

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/privileged/DeleteChatUseCaseTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/privileged/DeleteChatUseCaseTest.kt
@@ -32,7 +32,7 @@ class DeleteChatUseCaseTest {
 
         // Implement other required ChatRepository methods as not implemented for this test
         override suspend fun flowChatList() = error("Not implemented")
-        override fun isChatListUpdating() = kotlinx.coroutines.flow.flowOf(false)
+        override fun isChatListUpdateApplying() = kotlinx.coroutines.flow.flowOf(false)
         override suspend fun createChat(chat: timur.gilfanov.messenger.domain.entity.chat.Chat) =
             error("Not implemented")
         override suspend fun joinChat(chatId: ChatId, inviteLink: String?) =

--- a/app/src/test/java/timur/gilfanov/messenger/domain/usecase/repository/RepositoryFake.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/domain/usecase/repository/RepositoryFake.kt
@@ -61,7 +61,7 @@ class RepositoryFake :
             .distinctUntilChanged()
             .map { chats -> ResultWithError.Success(chats.map { ChatPreview.fromChat(it) }) }
 
-    override fun isChatListUpdating(): Flow<Boolean> = kotlinx.coroutines.flow.flowOf(false)
+    override fun isChatListUpdateApplying(): Flow<Boolean> = kotlinx.coroutines.flow.flowOf(false)
 
     override suspend fun createChat(chat: Chat): ResultWithError<Chat, CreateChatRepositoryError> {
         chats[chat.id] = chat

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
@@ -101,7 +101,7 @@ object ChatViewModelTestFixtures {
 
         // Implement other required ChatRepository methods as not implemented for this test
         override suspend fun flowChatList() = error("Not implemented")
-        override fun isChatListUpdating() = kotlinx.coroutines.flow.flowOf(false)
+        override fun isChatListUpdateApplying() = kotlinx.coroutines.flow.flowOf(false)
         override suspend fun createChat(chat: Chat) = error("Not implemented")
         override suspend fun deleteChat(chatId: ChatId) = error("Not implemented")
         override suspend fun joinChat(chatId: ChatId, inviteLink: String?) =
@@ -163,7 +163,7 @@ object ChatViewModelTestFixtures {
 
         // Implement other required ChatRepository methods as not implemented for this test
         override suspend fun flowChatList() = error("Not implemented")
-        override fun isChatListUpdating() = kotlinx.coroutines.flow.flowOf(false)
+        override fun isChatListUpdateApplying() = kotlinx.coroutines.flow.flowOf(false)
         override suspend fun createChat(chat: Chat) = error("Not implemented")
         override suspend fun deleteChat(chatId: ChatId) = error("Not implemented")
         override suspend fun joinChat(chatId: ChatId, inviteLink: String?) =
@@ -229,7 +229,7 @@ object ChatViewModelTestFixtures {
 
         // Implement other required ChatRepository methods as not implemented for this test
         override suspend fun flowChatList() = error("Not implemented")
-        override fun isChatListUpdating() = kotlinx.coroutines.flow.flowOf(false)
+        override fun isChatListUpdateApplying() = kotlinx.coroutines.flow.flowOf(false)
         override suspend fun createChat(chat: Chat) = error("Not implemented")
         override suspend fun deleteChat(chatId: ChatId) = error("Not implemented")
         override suspend fun joinChat(chatId: ChatId, inviteLink: String?) =

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/TestRepositoryWithRealImplementation.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/TestRepositoryWithRealImplementation.kt
@@ -174,7 +174,8 @@ class TestRepositoryWithRealImplementation :
         > =
         realRepository.flowChatList()
 
-    override fun isChatListUpdating(): Flow<Boolean> = realRepository.isChatListUpdating()
+    override fun isChatListUpdateApplying(): Flow<Boolean> =
+        realRepository.isChatListUpdateApplying()
 
     override suspend fun receiveChatUpdates(
         chatId: ChatId,

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListScreenComponentTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListScreenComponentTest.kt
@@ -50,7 +50,7 @@ class ChatListScreenComponentTest {
     private fun createTestScreenState(
         uiState: ChatListUiState = ChatListUiState.Empty,
         isLoading: Boolean = false,
-        isRefreshing: Boolean = false,
+        isChatListUpdateApplying: Boolean = false,
         error: FlowChatListRepositoryError? = null,
     ) = ChatListScreenState(
         uiState = uiState,
@@ -60,7 +60,7 @@ class ChatListScreenComponentTest {
             pictureUrl = null,
         ),
         isLoading = isLoading,
-        isRefreshing = isRefreshing,
+        isChatListUpdateApplying = isChatListUpdateApplying,
         error = error,
     )
 

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListViewModelComponentTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListViewModelComponentTest.kt
@@ -96,7 +96,7 @@ class ChatListViewModelComponentTest {
             > =
             chatListFlow
 
-        override fun isChatListUpdating(): Flow<Boolean> = updatingFlow
+        override fun isChatListUpdateApplying(): Flow<Boolean> = updatingFlow
 
         // Implement other required ChatRepository methods as not implemented for this test
         override suspend fun createChat(chat: timur.gilfanov.messenger.domain.entity.chat.Chat) =
@@ -138,7 +138,7 @@ class ChatListViewModelComponentTest {
 
             assertEquals(ChatListUiState.Empty, state.uiState)
             assertEquals(false, state.isLoading)
-            assertEquals(false, state.isRefreshing)
+            assertEquals(false, state.isChatListUpdateApplying)
             assertNull(state.error)
 
             job.cancelAndJoin()
@@ -185,7 +185,7 @@ class ChatListViewModelComponentTest {
             assertTrue(state.uiState is ChatListUiState.NotEmpty)
             assertEquals(0, state.uiState.chats.size)
             assertEquals(false, state.isLoading)
-            assertEquals(false, state.isRefreshing)
+            assertEquals(false, state.isChatListUpdateApplying)
             assertEquals(LocalOperationFailed(LocalStorageError.Corrupted), state.error)
 
             job.cancelAndJoin()
@@ -207,17 +207,17 @@ class ChatListViewModelComponentTest {
 
             // Initial state - wait for loaded
             val initialState = awaitLoadedState()
-            assertEquals(false, initialState.isRefreshing)
+            assertEquals(false, initialState.isChatListUpdateApplying)
 
             // Simulate refreshing
             updatingFlow.value = true
             val refreshingState = awaitState()
-            assertEquals(true, refreshingState.isRefreshing)
+            assertEquals(true, refreshingState.isChatListUpdateApplying)
 
             // Stop refreshing
             updatingFlow.value = false
             val finalState = awaitState()
-            assertEquals(false, finalState.isRefreshing)
+            assertEquals(false, finalState.isChatListUpdateApplying)
 
             job.cancelAndJoin()
         }
@@ -331,7 +331,7 @@ class ChatListViewModelComponentTest {
             val state = awaitLoadedState()
 
             assertEquals(false, state.isLoading)
-            assertEquals(false, state.isRefreshing)
+            assertEquals(false, state.isChatListUpdateApplying)
             assertEquals(LocalOperationFailed(LocalStorageError.Corrupted), state.error)
 
             job.cancelAndJoin()


### PR DESCRIPTION
## Summary
Renames `isChatListUpdating` and `isRefreshing` to `isChatListUpdateApplying` across the codebase to more accurately reflect that the state represents the process of applying delta updates to the local database.

Specific changes:
- Renamed `ChatRepository.isChatListUpdating()` to `isChatListUpdateApplying()`.
- Renamed `isRefreshing` to `isChatListUpdateApplying` in `ChatListUiState` and `ChatListScreenState`.
- Updated `ChatListViewModel` to map the repository flow to the new state property.
- Updated `MessengerRepositoryImpl` and all related test stubs, fakes, and unit tests to use the new naming.
- Adjusted UI components in `ChatListScreen` and `ChatListScreenComponentTest` to reflect the state change.

Closes #184.