### PR TITLE
fix: handle unauthorized profile observation in chat list

### DIFF
--- a/app/src/main/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListSideEffects.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/ui/screen/chatlist/ChatListSideEffects.kt
@@ -1,0 +1,5 @@
+package timur.gilfanov.messenger.ui.screen.chatlist
+
+sealed interface ChatListSideEffects {
+    data object Unauthorized : ChatListSideEffects
+}


### PR DESCRIPTION
### Motivation
- `ChatListViewModel` currently ignores failures from `observeProfile`, leaving the `Unauthorized` branch unhandled and the UI without a way to react.  
- Follow the same side-effect pattern used in `ProfileViewModel` to surface one-shot auth failures to the UI and log the error for diagnostics.

### Description
- Add `ChatListSideEffects` with a one-shot `Unauthorized` event at `app/src/main/java/.../ChatListSideEffects.kt`.  
- Update `ChatListViewModel` to inject `Logger`, expose `effects` via a `Channel` + `receiveAsFlow`, and emit `ChatListSideEffects.Unauthorized` while logging when `ObserveProfileError.Unauthorized` occurs.  
- Update `ChatListScreen` to collect `viewModel.effects` with lifecycle awareness and call a new `onAuthFailure` action callback when `ChatListSideEffects.Unauthorized` is received.  
- Add component tests in `ChatListViewModelComponentTest` including a `RecordingLogger` and tests to verify unauthorized effect emission and logging behavior, and update existing tests to supply the new `Logger` dependency.

### Testing
- Added unit/component tests in `app/src/test/.../ChatListViewModelComponentTest.kt` (new tests assert emission of `ChatListSideEffects.Unauthorized` and that a log entry is produced).  
- Attempted to run formatting, static analysis and unit tests via `./gradlew ktlintFormat detekt --auto-correct testMockDebugUnitTest lintMockDebug` and `./gradlew testMockDebugUnitTest`, but the Gradle build failed in this environment due to Java toolchain/Kotlin script parsing and then missing Android SDK (`SDK location not found`).  
- Workarounds were attempted by switching `JAVA_HOME` to JDK 17 before running Gradle, but the run still failed because an Android SDK location is not configured in this environment, so automated verification could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd93381048331834fe8a1748b48a7)
Closes #191.