### PR TITLE
Add `id-token: write` permission to Claude Agent workflow

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add missing `id-token: write` permission required by `claude-code-action@v1` for OIDC token authentication

## Test plan
- [ ] Re-run the agent workflow on issue #158 and verify it no longer fails with "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL"

🤖 Generated with [Claude Code](https://claude.com/claude-code)