### PR TITLE
docs: add cross-reference from ADR-001 to ADR-002

### DIFF
--- a/docs/architecture/ADR-001-introduce-multi-module-architecture.md
+++ b/docs/architecture/ADR-001-introduce-multi-module-architecture.md
@@ -25,3 +25,6 @@ Negative:
 
 ## Alternatives Considered
 1. Keep single-module architecture – rejected because it does not scale well with parallel feature development and makes ownership boundaries unclear as the codebase grows.
+
+## Related decisions
+- [ADR-002](ADR-002-module-creation-strategy.md): Module creation strategy


### PR DESCRIPTION
## Summary
- Add a "Related decisions" section to ADR-001 with a link to ADR-002 (Module creation strategy)
- Helps readers discover related architectural decisions

## Test plan
- [x] Verify the markdown link resolves correctly in the GitHub UI
- [x] Confirm ADR-001 renders properly with the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)