### PR TITLE
fix(domain): enforce UnauthRemoteError for unauthenticated repository operations

### DIFF
--- a/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/GoogleLoginRepositoryError.kt
+++ b/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/GoogleLoginRepositoryError.kt
@@ -1,7 +1,7 @@
 package timur.gilfanov.messenger.domain.usecase.auth.repository
 
 import timur.gilfanov.messenger.domain.usecase.common.LocalStorageError
-import timur.gilfanov.messenger.domain.usecase.common.RemoteError
+import timur.gilfanov.messenger.domain.usecase.common.UnauthRemoteError
 
 /**
  * Errors for Google login repository operations.
@@ -20,5 +20,5 @@ sealed interface GoogleLoginRepositoryError {
     data object AccountNotFound : GoogleLoginRepositoryError
     data object AccountSuspended : GoogleLoginRepositoryError
     data class LocalOperationFailed(val error: LocalStorageError) : GoogleLoginRepositoryError
-    data class RemoteOperationFailed(val error: RemoteError) : GoogleLoginRepositoryError
+    data class RemoteOperationFailed(val error: UnauthRemoteError) : GoogleLoginRepositoryError
 }

--- a/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/LoginRepositoryError.kt
+++ b/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/LoginRepositoryError.kt
@@ -1,7 +1,7 @@
 package timur.gilfanov.messenger.domain.usecase.auth.repository
 
 import timur.gilfanov.messenger.domain.usecase.common.LocalStorageError
-import timur.gilfanov.messenger.domain.usecase.common.RemoteError
+import timur.gilfanov.messenger.domain.usecase.common.UnauthRemoteError
 
 /**
  * Errors for email/password login repository operations.
@@ -22,5 +22,5 @@ sealed interface LoginRepositoryError {
     data object EmailNotVerified : LoginRepositoryError
     data object AccountSuspended : LoginRepositoryError
     data class LocalOperationFailed(val error: LocalStorageError) : LoginRepositoryError
-    data class RemoteOperationFailed(val error: RemoteError) : LoginRepositoryError
+    data class RemoteOperationFailed(val error: UnauthRemoteError) : LoginRepositoryError
 }

--- a/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/SignupRepositoryError.kt
+++ b/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/SignupRepositoryError.kt
@@ -1,7 +1,7 @@
 package timur.gilfanov.messenger.domain.usecase.auth.repository
 
 import timur.gilfanov.messenger.domain.usecase.common.LocalStorageError
-import timur.gilfanov.messenger.domain.usecase.common.RemoteError
+import timur.gilfanov.messenger.domain.usecase.common.UnauthRemoteError
 
 /**
  * Errors for account signup repository operations.
@@ -20,5 +20,5 @@ sealed interface SignupRepositoryError {
     data class InvalidPassword(val reason: PasswordValidationError) : SignupRepositoryError
     data class InvalidName(val reason: ProfileNameValidationError) : SignupRepositoryError
     data class LocalOperationFailed(val error: LocalStorageError) : SignupRepositoryError
-    data class RemoteOperationFailed(val error: RemoteError) : SignupRepositoryError
+    data class RemoteOperationFailed(val error: UnauthRemoteError) : SignupRepositoryError
 }

--- a/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/common/RemoteError.kt
+++ b/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/common/RemoteError.kt
@@ -3,6 +3,14 @@ package timur.gilfanov.messenger.domain.usecase.common
 import kotlin.time.Duration
 
 /**
+ * Subset of [RemoteError] that is valid for unauthenticated operations (login, signup).
+ *
+ * Excludes [RemoteError.Unauthenticated] and [RemoteError.InsufficientPermissions], which are
+ * logically impossible for operations that do not require an existing session.
+ */
+sealed interface UnauthRemoteError
+
+/**
  * Common error taxonomy for repository operations involving remote data.
  *
  * Introduced to remove duplication across multiple use cases that share similar error modes.
@@ -29,7 +37,9 @@ sealed interface RemoteError {
      * layers, such as network connectivity, service throttling, or unexpected infrastructure
      * issues.
      */
-    sealed interface Failed : RemoteError {
+    sealed interface Failed :
+        RemoteError,
+        UnauthRemoteError {
         /** No network connectivity at the moment of the operation attempt. */
         data object NetworkNotAvailable : Failed
 
@@ -51,7 +61,9 @@ sealed interface RemoteError {
      * The operation outcome is unknown (e.g., request timed out after being sent). Callers may need
      * to query status or re-attempt once the underlying condition clears.
      */
-    sealed interface UnknownStatus : RemoteError {
+    sealed interface UnknownStatus :
+        RemoteError,
+        UnauthRemoteError {
         /** Request timed out before the service confirmed success or failure. */
         data object ServiceTimeout : UnknownStatus
     }


### PR DESCRIPTION
Closes #273

## Summary
`RemoteError.Unauthenticated` and `RemoteError.InsufficientPermissions` are logically impossible for operations that do not require an existing session (login, signup), but were representable via `RemoteOperationFailed(val error: RemoteError)`. This PR makes the invariant compile-time enforced.

## Changes
- Add `sealed interface UnauthRemoteError` to `RemoteError.kt`; implemented by `RemoteError.Failed` and `RemoteError.UnknownStatus` — excludes `Unauthenticated` and `InsufficientPermissions`
- `LoginRepositoryError.RemoteOperationFailed` now carries `UnauthRemoteError` instead of `RemoteError`
- `GoogleLoginRepositoryError.RemoteOperationFailed` now carries `UnauthRemoteError` instead of `RemoteError`
- `SignupRepositoryError.RemoteOperationFailed` now carries `UnauthRemoteError` instead of `RemoteError`

## Important Design Decision
`UnauthRemoteError` is a sealed marker interface rather than a duplicate sealed hierarchy — existing leaf types (`NetworkNotAvailable`, `ServiceDown`, `Cooldown`, `UnknownServiceError`, `ServiceTimeout`) satisfy it automatically via their parent `Failed`/`UnknownStatus`. Zero duplication, exhaustive `when` branches remain possible.

## Breaking Changes
`RemoteOperationFailed.error` type narrowed from `RemoteError` to `UnauthRemoteError` in `LoginRepositoryError`, `GoogleLoginRepositoryError`, and `SignupRepositoryError`. Any code constructing these with `Unauthenticated` or `InsufficientPermissions` will not compile — which is intentional.