### PR TITLE
chore(auth): add Google server client ID

### DIFF
--- a/feature/auth/src/main/res/values/strings.xml
+++ b/feature/auth/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="login_error_password_must_contain_numbers">Password must contain at least %d number(s)</string>
     <string name="login_error_password_must_contain_alphabet">Password must contain at least %d letter(s)</string>
 
-    <string name="google_server_client_id" translatable="false">954783563995-llnm7in939j1011t0hmcm8br7sja2ivp.apps.googleusercontent.com</string>
+    <string name="google_server_client_id" translatable="false">954783563995-s2vqh91na4he5lad90srq57mrv64bium.apps.googleusercontent.com</string>
 
     <!-- Login blocking error titles -->
     <string name="login_error_storage_full_title">Storage full</string>


### PR DESCRIPTION
Closes #302

## Summary
Replace the `google_server_client_id` placeholder with the actual Web OAuth 2.0 client ID based on the debug keystore, enabling Google Sign-In to function at runtime.

## Changes
- Replace placeholder TODO string with real Web OAuth client ID in `feature/auth/src/main/res/values/strings.xml`

## Testing
- [ ] Unit tests added or updated
- [x] Manually tested

## Acceptance criteria
- [x] `google_server_client_id` no longer holds a placeholder value
- [x] Google Sign-In flow works at runtime with the debug build