### PR TITLE
feat(auth): real-time field validation on Login and Signup screens

### DIFF
--- a/docs/plans/2026-04-06-real-time-field-validation-login-signup.md
+++ b/docs/plans/2026-04-06-real-time-field-validation-login-signup.md
@@ -44,10 +44,10 @@ displaying these errors; only the ViewModels need to change.
 **Files:**
 - Modify: `feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt`
 
-- [ ] In `updateName()`: extract failure reason from `profileNameValidator.validate()` and set `nameError`; clear on success
-- [ ] In `updateEmail()`: same extraction pattern as LoginViewModel
-- [ ] In `updatePassword()`: same extraction pattern as LoginViewModel
-- [ ] Run `./gradlew ktlintFormat detekt --auto-correct`
+- [x] In `updateName()`: extract failure reason from `profileNameValidator.validate()` and set `nameError`; clear on success
+- [x] In `updateEmail()`: same extraction pattern as LoginViewModel
+- [x] In `updatePassword()`: same extraction pattern as LoginViewModel
+- [x] Run `./gradlew ktlintFormat detekt --auto-correct`
 
 ### Task 3: ViewModel unit tests
 

--- a/docs/plans/2026-04-06-real-time-field-validation-login-signup.md
+++ b/docs/plans/2026-04-06-real-time-field-validation-login-signup.md
@@ -55,14 +55,14 @@ displaying these errors; only the ViewModels need to change.
 - Create: `feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt`
 - Create: `feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt`
 
-- [ ] LoginViewModel: entering invalid email sets `emailError`; fixing it clears `emailError`
-- [ ] LoginViewModel: entering invalid password sets `passwordError`; fixing it clears `passwordError`
-- [ ] LoginViewModel: email error does not appear in initial state (before any edits)
-- [ ] SignupViewModel: entering invalid name sets `nameError`; fixing it clears `nameError`
-- [ ] SignupViewModel: entering invalid email sets `emailError`; fixing it clears `emailError`
-- [ ] SignupViewModel: entering invalid password sets `passwordError`; fixing it clears `passwordError`
-- [ ] SignupViewModel: name/email error do not appear on restore from SavedStateHandle (before any edits in current session)
-- [ ] Run `./gradlew :feature:auth:testDebugUnitTest`
+- [x] LoginViewModel: entering invalid email sets `emailError`; fixing it clears `emailError`
+- [x] LoginViewModel: entering invalid password sets `passwordError`; fixing it clears `passwordError`
+- [x] LoginViewModel: email error does not appear in initial state (before any edits)
+- [x] SignupViewModel: entering invalid name sets `nameError`; fixing it clears `nameError`
+- [x] SignupViewModel: entering invalid email sets `emailError`; fixing it clears `emailError`
+- [x] SignupViewModel: entering invalid password sets `passwordError`; fixing it clears `passwordError`
+- [x] SignupViewModel: name/email error do not appear on restore from SavedStateHandle (before any edits in current session)
+- [x] Run `./gradlew :feature:auth:testDebugUnitTest`
 
 ### Task 4: Verify acceptance criteria
 

--- a/docs/plans/2026-04-06-real-time-field-validation-login-signup.md
+++ b/docs/plans/2026-04-06-real-time-field-validation-login-signup.md
@@ -1,0 +1,71 @@
+# Real-Time Field Validation on Login and Signup Screens (#321)
+
+## Overview
+Wire the existing validators to set per-field inline errors in the ViewModels during field
+updates, not only on form submission. The UI composables and UiState types already support
+displaying these errors; only the ViewModels need to change.
+
+## Context
+- Files involved:
+  - `feature/auth/src/main/kotlin/.../ui/screen/login/LoginViewModel.kt`
+  - `feature/auth/src/main/kotlin/.../ui/screen/signup/SignupViewModel.kt`
+  - `feature/auth/src/test/kotlin/.../ui/LoginViewModelRealTimeValidationTest.kt` (new)
+  - `feature/auth/src/test/kotlin/.../ui/SignupViewModelRealTimeValidationTest.kt` (new)
+- Related patterns:
+  - `CredentialsValidationError.Email(reason)` where `reason: EmailValidationError`
+    implements `LoginEmailError` and `SignupEmailError` directly — no mapping needed
+  - `CredentialsValidationError.Password(reason)` where `reason: PasswordValidationError`
+  - The UI already reads `state.emailError`, `state.passwordError`, `state.nameError` and
+    passes them to `supportingText`/`isError` — no UI changes needed
+  - UiState already has all error fields — no UiState changes needed
+  - `isSubmitEnabled` already guards on both `isCredentialsValid` and `emailError == null`
+    — button behavior unchanged
+- Dependencies: none
+
+## Development Approach
+- **Testing approach**: Regular (code first, then tests)
+- Complete each task fully before moving to the next
+- **CRITICAL: every task MUST include new/updated tests**
+- **CRITICAL: all tests must pass before starting next task**
+
+## Implementation Steps
+
+### Task 1: Real-time validation in LoginViewModel
+
+**Files:**
+- Modify: `feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt`
+
+- [x] In `updateEmail()`: run `credentialsValidator.validate()`, extract `CredentialsValidationError.Email(reason)` if present and set `emailError = reason`; otherwise set `emailError = null`
+- [x] In `updatePassword()`: run `credentialsValidator.validate()`, extract `CredentialsValidationError.Password(reason)` if present and set `passwordError = reason`; otherwise set `passwordError = null`
+- [x] Run `./gradlew ktlintFormat detekt --auto-correct`
+
+### Task 2: Real-time validation in SignupViewModel
+
+**Files:**
+- Modify: `feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt`
+
+- [ ] In `updateName()`: extract failure reason from `profileNameValidator.validate()` and set `nameError`; clear on success
+- [ ] In `updateEmail()`: same extraction pattern as LoginViewModel
+- [ ] In `updatePassword()`: same extraction pattern as LoginViewModel
+- [ ] Run `./gradlew ktlintFormat detekt --auto-correct`
+
+### Task 3: ViewModel unit tests
+
+**Files:**
+- Create: `feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt`
+- Create: `feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt`
+
+- [ ] LoginViewModel: entering invalid email sets `emailError`; fixing it clears `emailError`
+- [ ] LoginViewModel: entering invalid password sets `passwordError`; fixing it clears `passwordError`
+- [ ] LoginViewModel: email error does not appear in initial state (before any edits)
+- [ ] SignupViewModel: entering invalid name sets `nameError`; fixing it clears `nameError`
+- [ ] SignupViewModel: entering invalid email sets `emailError`; fixing it clears `emailError`
+- [ ] SignupViewModel: entering invalid password sets `passwordError`; fixing it clears `passwordError`
+- [ ] SignupViewModel: name/email error do not appear on restore from SavedStateHandle (before any edits in current session)
+- [ ] Run `./gradlew :feature:auth:testDebugUnitTest`
+
+### Task 4: Verify acceptance criteria
+
+- [ ] Run full test suite: `./gradlew :feature:auth:testDebugUnitTest`
+- [ ] Run linter: `./gradlew ktlintFormat detekt --auto-correct`
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/completed/2026-04-06-real-time-field-validation-login-signup.md
+++ b/docs/plans/completed/2026-04-06-real-time-field-validation-login-signup.md
@@ -66,6 +66,6 @@ displaying these errors; only the ViewModels need to change.
 
 ### Task 4: Verify acceptance criteria
 
-- [ ] Run full test suite: `./gradlew :feature:auth:testDebugUnitTest`
-- [ ] Run linter: `./gradlew ktlintFormat detekt --auto-correct`
-- [ ] Move this plan to `docs/plans/completed/`
+- [x] Run full test suite: `./gradlew :feature:auth:testDebugUnitTest`
+- [x] Run linter: `./gradlew ktlintFormat detekt --auto-correct`
+- [x] Move this plan to `docs/plans/completed/`

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidator.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidator.kt
@@ -2,7 +2,13 @@ package timur.gilfanov.messenger.auth.domain.validation
 
 import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.auth.Credentials
+import timur.gilfanov.messenger.domain.entity.auth.Email
+import timur.gilfanov.messenger.domain.entity.auth.Password
+import timur.gilfanov.messenger.domain.usecase.auth.repository.EmailValidationError
+import timur.gilfanov.messenger.domain.usecase.auth.repository.PasswordValidationError
 
 interface CredentialsValidator {
     fun validate(credentials: Credentials): ResultWithError<Unit, CredentialsValidationError>
+    fun validate(email: Email): ResultWithError<Unit, EmailValidationError>
+    fun validate(password: Password): ResultWithError<Unit, PasswordValidationError>
 }

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImpl.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImpl.kt
@@ -2,6 +2,8 @@ package timur.gilfanov.messenger.auth.domain.validation
 
 import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.auth.Credentials
+import timur.gilfanov.messenger.domain.entity.auth.Email
+import timur.gilfanov.messenger.domain.entity.auth.Password
 import timur.gilfanov.messenger.domain.usecase.auth.repository.EmailValidationError
 import timur.gilfanov.messenger.domain.usecase.auth.repository.PasswordValidationError
 
@@ -19,66 +21,49 @@ class CredentialsValidatorImpl : CredentialsValidator {
     override fun validate(
         credentials: Credentials,
     ): ResultWithError<Unit, CredentialsValidationError> {
-        val emailResult = validateEmail(credentials.email.value)
-        if (emailResult is ResultWithError.Failure) return emailResult
-        return validatePassword(credentials.password.value)
+        val emailResult = validate(credentials.email)
+        if (emailResult is ResultWithError.Failure) {
+            return ResultWithError.Failure(CredentialsValidationError.Email(emailResult.error))
+        }
+        return when (val passwordResult = validate(credentials.password)) {
+            is ResultWithError.Failure ->
+                ResultWithError.Failure(CredentialsValidationError.Password(passwordResult.error))
+            is ResultWithError.Success -> ResultWithError.Success(Unit)
+        }
     }
 
-    private fun validateEmail(
-        email: String,
-    ): ResultWithError<Unit, CredentialsValidationError.Email> = when {
-        email.isBlank() ->
-            ResultWithError.Failure(
-                CredentialsValidationError.Email(EmailValidationError.BlankEmail),
-            )
-        !email.contains('@') ->
-            ResultWithError.Failure(
-                CredentialsValidationError.Email(EmailValidationError.NoAtInEmail),
-            )
-        email.substringAfter('@').isEmpty() ->
-            ResultWithError.Failure(
-                CredentialsValidationError.Email(EmailValidationError.NoDomainAtEmail),
-            )
-        email.length > MAX_EMAIL_LENGTH ->
-            ResultWithError.Failure(
-                CredentialsValidationError.Email(
-                    EmailValidationError.EmailTooLong(MAX_EMAIL_LENGTH),
-                ),
-            )
-        !EMAIL_REGEX.matches(email) ->
-            ResultWithError.Failure(
-                CredentialsValidationError.Email(EmailValidationError.InvalidEmailFormat),
-            )
+    override fun validate(email: Email): ResultWithError<Unit, EmailValidationError> = when {
+        email.value.isBlank() ->
+            ResultWithError.Failure(EmailValidationError.BlankEmail)
+        !email.value.contains('@') ->
+            ResultWithError.Failure(EmailValidationError.NoAtInEmail)
+        email.value.substringAfter('@').isEmpty() ->
+            ResultWithError.Failure(EmailValidationError.NoDomainAtEmail)
+        email.value.length > MAX_EMAIL_LENGTH ->
+            ResultWithError.Failure(EmailValidationError.EmailTooLong(MAX_EMAIL_LENGTH))
+        !EMAIL_REGEX.matches(email.value) ->
+            ResultWithError.Failure(EmailValidationError.InvalidEmailFormat)
         else -> ResultWithError.Success(Unit)
     }
 
-    private fun validatePassword(
-        password: String,
-    ): ResultWithError<Unit, CredentialsValidationError.Password> = when {
-        password.length < MIN_PASSWORD_LENGTH ->
-            ResultWithError.Failure(
-                CredentialsValidationError.Password(
+    override fun validate(password: Password): ResultWithError<Unit, PasswordValidationError> =
+        when {
+            password.value.length < MIN_PASSWORD_LENGTH ->
+                ResultWithError.Failure(
                     PasswordValidationError.PasswordTooShort(MIN_PASSWORD_LENGTH),
-                ),
-            )
-        password.length > MAX_PASSWORD_LENGTH ->
-            ResultWithError.Failure(
-                CredentialsValidationError.Password(
+                )
+            password.value.length > MAX_PASSWORD_LENGTH ->
+                ResultWithError.Failure(
                     PasswordValidationError.PasswordTooLong(MAX_PASSWORD_LENGTH),
-                ),
-            )
-        password.count { it.isDigit() } < MIN_NUMBERS_IN_PASSWORD ->
-            ResultWithError.Failure(
-                CredentialsValidationError.Password(
+                )
+            password.value.count { it.isDigit() } < MIN_NUMBERS_IN_PASSWORD ->
+                ResultWithError.Failure(
                     PasswordValidationError.PasswordMustContainNumbers(MIN_NUMBERS_IN_PASSWORD),
-                ),
-            )
-        password.count { it.isLetter() } < MIN_ALPHABET_IN_PASSWORD ->
-            ResultWithError.Failure(
-                CredentialsValidationError.Password(
+                )
+            password.value.count { it.isLetter() } < MIN_ALPHABET_IN_PASSWORD ->
+                ResultWithError.Failure(
                     PasswordValidationError.PasswordMustContainAlphabet(MIN_ALPHABET_IN_PASSWORD),
-                ),
-            )
-        else -> ResultWithError.Success(Unit)
-    }
+                )
+            else -> ResultWithError.Success(Unit)
+        }
 }

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
@@ -65,16 +65,10 @@ class LoginViewModel @Inject constructor(
         val isCredentialsValid = validationResult is ResultWithError.Success
         val validationFailure = (validationResult as? ResultWithError.Failure)?.error
         val emailError = (validationFailure as? CredentialsValidationError.Email)?.reason
-        val passwordError = when (validationFailure) {
-            is CredentialsValidationError.Email -> _state.value.passwordError
-            is CredentialsValidationError.Password -> validationFailure.reason
-            null -> null
-        }
         _state.update {
             it.copy(
                 email = email,
                 emailError = emailError,
-                passwordError = passwordError,
                 isCredentialsValid = isCredentialsValid,
             )
         }
@@ -89,7 +83,14 @@ class LoginViewModel @Inject constructor(
         val validationFailure = (validationResult as? ResultWithError.Failure)?.error
         val passwordError = when (validationFailure) {
             is CredentialsValidationError.Password -> validationFailure.reason
-            is CredentialsValidationError.Email -> _state.value.passwordError
+            is CredentialsValidationError.Email -> {
+                val passwordOnlyResult = credentialsValidator.validate(
+                    Credentials(Email("placeholder@example.com"), Password(password)),
+                )
+                (passwordOnlyResult as? ResultWithError.Failure)
+                    ?.error
+                    ?.let { (it as? CredentialsValidationError.Password)?.reason }
+            }
             null -> null
         }
         _state.update {

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
@@ -15,7 +15,6 @@ import timur.gilfanov.messenger.auth.domain.usecase.GoogleLoginUseCaseError
 import timur.gilfanov.messenger.auth.domain.usecase.LoginUseCaseError
 import timur.gilfanov.messenger.auth.domain.usecase.LoginWithCredentialsUseCase
 import timur.gilfanov.messenger.auth.domain.usecase.LoginWithGoogleUseCase
-import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidationError
 import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidator
 import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.auth.Credentials
@@ -59,12 +58,14 @@ class LoginViewModel @Inject constructor(
     fun updateEmail(email: String) {
         savedStateHandle[KEY_EMAIL] = email
         val currentPassword = _state.value.password
-        val validationResult = credentialsValidator.validate(
+        val isCredentialsValid = credentialsValidator.validate(
             Credentials(Email(email), Password(currentPassword)),
-        )
-        val isCredentialsValid = validationResult is ResultWithError.Success
-        val validationFailure = (validationResult as? ResultWithError.Failure)?.error
-        val emailError = (validationFailure as? CredentialsValidationError.Email)?.reason
+        ) is ResultWithError.Success
+        val emailError = (
+            credentialsValidator.validate(
+                Email(email),
+            ) as? ResultWithError.Failure
+            )?.error
         _state.update {
             it.copy(
                 email = email,
@@ -76,23 +77,11 @@ class LoginViewModel @Inject constructor(
 
     fun updatePassword(password: String) {
         val currentEmail = _state.value.email
-        val validationResult = credentialsValidator.validate(
+        val isCredentialsValid = credentialsValidator.validate(
             Credentials(Email(currentEmail), Password(password)),
-        )
-        val isCredentialsValid = validationResult is ResultWithError.Success
-        val validationFailure = (validationResult as? ResultWithError.Failure)?.error
-        val passwordError = when (validationFailure) {
-            is CredentialsValidationError.Password -> validationFailure.reason
-            is CredentialsValidationError.Email -> {
-                val passwordOnlyResult = credentialsValidator.validate(
-                    Credentials(Email("placeholder@example.com"), Password(password)),
-                )
-                (passwordOnlyResult as? ResultWithError.Failure)
-                    ?.error
-                    ?.let { (it as? CredentialsValidationError.Password)?.reason }
-            }
-            null -> null
-        }
+        ) is ResultWithError.Success
+        val passwordError =
+            (credentialsValidator.validate(Password(password)) as? ResultWithError.Failure)?.error
         _state.update {
             it.copy(
                 password = password,

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
@@ -15,6 +15,7 @@ import timur.gilfanov.messenger.auth.domain.usecase.GoogleLoginUseCaseError
 import timur.gilfanov.messenger.auth.domain.usecase.LoginUseCaseError
 import timur.gilfanov.messenger.auth.domain.usecase.LoginWithCredentialsUseCase
 import timur.gilfanov.messenger.auth.domain.usecase.LoginWithGoogleUseCase
+import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidationError
 import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidator
 import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.auth.Credentials
@@ -58,23 +59,31 @@ class LoginViewModel @Inject constructor(
     fun updateEmail(email: String) {
         savedStateHandle[KEY_EMAIL] = email
         val currentPassword = _state.value.password
-        val isCredentialsValid = credentialsValidator.validate(
+        val validationResult = credentialsValidator.validate(
             Credentials(Email(email), Password(currentPassword)),
-        ) is ResultWithError.Success
+        )
+        val isCredentialsValid = validationResult is ResultWithError.Success
+        val emailError = (validationResult as? ResultWithError.Failure)
+            ?.let { it.error as? CredentialsValidationError.Email }
+            ?.reason
         _state.update {
-            it.copy(email = email, emailError = null, isCredentialsValid = isCredentialsValid)
+            it.copy(email = email, emailError = emailError, isCredentialsValid = isCredentialsValid)
         }
     }
 
     fun updatePassword(password: String) {
         val currentEmail = _state.value.email
-        val isCredentialsValid = credentialsValidator.validate(
+        val validationResult = credentialsValidator.validate(
             Credentials(Email(currentEmail), Password(password)),
-        ) is ResultWithError.Success
+        )
+        val isCredentialsValid = validationResult is ResultWithError.Success
+        val passwordError = (validationResult as? ResultWithError.Failure)
+            ?.let { it.error as? CredentialsValidationError.Password }
+            ?.reason
         _state.update {
             it.copy(
                 password = password,
-                passwordError = null,
+                passwordError = passwordError,
                 isCredentialsValid = isCredentialsValid,
             )
         }

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
@@ -63,11 +63,20 @@ class LoginViewModel @Inject constructor(
             Credentials(Email(email), Password(currentPassword)),
         )
         val isCredentialsValid = validationResult is ResultWithError.Success
-        val emailError = (validationResult as? ResultWithError.Failure)
-            ?.let { it.error as? CredentialsValidationError.Email }
-            ?.reason
+        val validationFailure = (validationResult as? ResultWithError.Failure)?.error
+        val emailError = (validationFailure as? CredentialsValidationError.Email)?.reason
+        val passwordError = when (validationFailure) {
+            is CredentialsValidationError.Email -> _state.value.passwordError
+            is CredentialsValidationError.Password -> validationFailure.reason
+            null -> null
+        }
         _state.update {
-            it.copy(email = email, emailError = emailError, isCredentialsValid = isCredentialsValid)
+            it.copy(
+                email = email,
+                emailError = emailError,
+                passwordError = passwordError,
+                isCredentialsValid = isCredentialsValid,
+            )
         }
     }
 
@@ -77,9 +86,12 @@ class LoginViewModel @Inject constructor(
             Credentials(Email(currentEmail), Password(password)),
         )
         val isCredentialsValid = validationResult is ResultWithError.Success
-        val passwordError = (validationResult as? ResultWithError.Failure)
-            ?.let { it.error as? CredentialsValidationError.Password }
-            ?.reason
+        val validationFailure = (validationResult as? ResultWithError.Failure)?.error
+        val passwordError = when (validationFailure) {
+            is CredentialsValidationError.Password -> validationFailure.reason
+            is CredentialsValidationError.Email -> _state.value.passwordError
+            null -> null
+        }
         _state.update {
             it.copy(
                 password = password,

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
@@ -41,13 +41,20 @@ class SignupViewModel @Inject constructor(
         run {
             val name: String = savedStateHandle[KEY_NAME] ?: ""
             val email: String = savedStateHandle[KEY_EMAIL] ?: ""
+            val nameValidation =
+                if (name.isNotEmpty()) profileNameValidator.validate(name) else null
+            val emailValidation =
+                if (email.isNotEmpty()) credentialsValidator.validate(Email(email)) else null
+            val credentialsValidation = credentialsValidator.validate(
+                Credentials(Email(email), Password("")),
+            )
             SignupUiState(
                 name = name,
                 email = email,
-                isNameValid = profileNameValidator.validate(name) is ResultWithError.Success,
-                isCredentialsValid = credentialsValidator.validate(
-                    Credentials(Email(email), Password("")),
-                ) is ResultWithError.Success,
+                isNameValid = nameValidation is ResultWithError.Success,
+                nameError = (nameValidation as? ResultWithError.Failure)?.error,
+                isCredentialsValid = credentialsValidation is ResultWithError.Success,
+                emailError = (emailValidation as? ResultWithError.Failure)?.error,
             )
         },
     )

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
@@ -15,7 +15,6 @@ import timur.gilfanov.messenger.auth.domain.usecase.SignupWithCredentialsUseCase
 import timur.gilfanov.messenger.auth.domain.usecase.SignupWithCredentialsUseCaseError
 import timur.gilfanov.messenger.auth.domain.usecase.SignupWithGoogleUseCase
 import timur.gilfanov.messenger.auth.domain.usecase.SignupWithGoogleUseCaseError
-import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidationError
 import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidator
 import timur.gilfanov.messenger.auth.domain.validation.ProfileNameValidator
 import timur.gilfanov.messenger.domain.entity.ResultWithError
@@ -80,12 +79,14 @@ class SignupViewModel @Inject constructor(
     fun updateEmail(email: String) {
         savedStateHandle[KEY_EMAIL] = email
         val currentPassword = _state.value.password
-        val validationResult = credentialsValidator.validate(
+        val isCredentialsValid = credentialsValidator.validate(
             Credentials(Email(email), Password(currentPassword)),
-        )
-        val isCredentialsValid = validationResult is ResultWithError.Success
-        val validationFailure = (validationResult as? ResultWithError.Failure)?.error
-        val emailError = (validationFailure as? CredentialsValidationError.Email)?.reason
+        ) is ResultWithError.Success
+        val emailError = (
+            credentialsValidator.validate(
+                Email(email),
+            ) as? ResultWithError.Failure
+            )?.error
         _state.update {
             it.copy(
                 email = email,
@@ -97,23 +98,11 @@ class SignupViewModel @Inject constructor(
 
     fun updatePassword(password: String) {
         val currentEmail = _state.value.email
-        val validationResult = credentialsValidator.validate(
+        val isCredentialsValid = credentialsValidator.validate(
             Credentials(Email(currentEmail), Password(password)),
-        )
-        val isCredentialsValid = validationResult is ResultWithError.Success
-        val validationFailure = (validationResult as? ResultWithError.Failure)?.error
-        val passwordError = when (validationFailure) {
-            is CredentialsValidationError.Password -> validationFailure.reason
-            is CredentialsValidationError.Email -> {
-                val passwordOnlyResult = credentialsValidator.validate(
-                    Credentials(Email("placeholder@example.com"), Password(password)),
-                )
-                (passwordOnlyResult as? ResultWithError.Failure)
-                    ?.error
-                    ?.let { (it as? CredentialsValidationError.Password)?.reason }
-            }
-            null -> null
-        }
+        ) is ResultWithError.Success
+        val passwordError =
+            (credentialsValidator.validate(Password(password)) as? ResultWithError.Failure)?.error
         val currentConfirmPassword = _state.value.confirmPassword
         val isPasswordConfirmed = password == currentConfirmPassword
         _state.update {

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
@@ -86,16 +86,10 @@ class SignupViewModel @Inject constructor(
         val isCredentialsValid = validationResult is ResultWithError.Success
         val validationFailure = (validationResult as? ResultWithError.Failure)?.error
         val emailError = (validationFailure as? CredentialsValidationError.Email)?.reason
-        val passwordError = when (validationFailure) {
-            is CredentialsValidationError.Email -> _state.value.passwordError
-            is CredentialsValidationError.Password -> validationFailure.reason
-            null -> null
-        }
         _state.update {
             it.copy(
                 email = email,
                 emailError = emailError,
-                passwordError = passwordError,
                 isCredentialsValid = isCredentialsValid,
             )
         }
@@ -110,7 +104,14 @@ class SignupViewModel @Inject constructor(
         val validationFailure = (validationResult as? ResultWithError.Failure)?.error
         val passwordError = when (validationFailure) {
             is CredentialsValidationError.Password -> validationFailure.reason
-            is CredentialsValidationError.Email -> _state.value.passwordError
+            is CredentialsValidationError.Email -> {
+                val passwordOnlyResult = credentialsValidator.validate(
+                    Credentials(Email("placeholder@example.com"), Password(password)),
+                )
+                (passwordOnlyResult as? ResultWithError.Failure)
+                    ?.error
+                    ?.let { (it as? CredentialsValidationError.Password)?.reason }
+            }
             null -> null
         }
         val currentConfirmPassword = _state.value.confirmPassword

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
@@ -15,6 +15,7 @@ import timur.gilfanov.messenger.auth.domain.usecase.SignupWithCredentialsUseCase
 import timur.gilfanov.messenger.auth.domain.usecase.SignupWithCredentialsUseCaseError
 import timur.gilfanov.messenger.auth.domain.usecase.SignupWithGoogleUseCase
 import timur.gilfanov.messenger.auth.domain.usecase.SignupWithGoogleUseCaseError
+import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidationError
 import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidator
 import timur.gilfanov.messenger.auth.domain.validation.ProfileNameValidator
 import timur.gilfanov.messenger.domain.entity.ResultWithError
@@ -70,32 +71,42 @@ class SignupViewModel @Inject constructor(
 
     fun updateName(name: String) {
         savedStateHandle[KEY_NAME] = name
-        val isNameValid = profileNameValidator.validate(name) is ResultWithError.Success
-        _state.update { it.copy(name = name, nameError = null, isNameValid = isNameValid) }
+        val nameValidationResult = profileNameValidator.validate(name)
+        val isNameValid = nameValidationResult is ResultWithError.Success
+        val nameError = (nameValidationResult as? ResultWithError.Failure)?.error
+        _state.update { it.copy(name = name, nameError = nameError, isNameValid = isNameValid) }
     }
 
     fun updateEmail(email: String) {
         savedStateHandle[KEY_EMAIL] = email
         val currentPassword = _state.value.password
-        val isCredentialsValid = credentialsValidator.validate(
+        val validationResult = credentialsValidator.validate(
             Credentials(Email(email), Password(currentPassword)),
-        ) is ResultWithError.Success
+        )
+        val isCredentialsValid = validationResult is ResultWithError.Success
+        val emailError = (validationResult as? ResultWithError.Failure)
+            ?.let { it.error as? CredentialsValidationError.Email }
+            ?.reason
         _state.update {
-            it.copy(email = email, emailError = null, isCredentialsValid = isCredentialsValid)
+            it.copy(email = email, emailError = emailError, isCredentialsValid = isCredentialsValid)
         }
     }
 
     fun updatePassword(password: String) {
         val currentEmail = _state.value.email
-        val isCredentialsValid = credentialsValidator.validate(
+        val validationResult = credentialsValidator.validate(
             Credentials(Email(currentEmail), Password(password)),
-        ) is ResultWithError.Success
+        )
+        val isCredentialsValid = validationResult is ResultWithError.Success
+        val passwordError = (validationResult as? ResultWithError.Failure)
+            ?.let { it.error as? CredentialsValidationError.Password }
+            ?.reason
         val currentConfirmPassword = _state.value.confirmPassword
         val isPasswordConfirmed = password == currentConfirmPassword
         _state.update {
             it.copy(
                 password = password,
-                passwordError = null,
+                passwordError = passwordError,
                 isCredentialsValid = isCredentialsValid,
                 isPasswordConfirmed = isPasswordConfirmed,
             )

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
@@ -84,11 +84,20 @@ class SignupViewModel @Inject constructor(
             Credentials(Email(email), Password(currentPassword)),
         )
         val isCredentialsValid = validationResult is ResultWithError.Success
-        val emailError = (validationResult as? ResultWithError.Failure)
-            ?.let { it.error as? CredentialsValidationError.Email }
-            ?.reason
+        val validationFailure = (validationResult as? ResultWithError.Failure)?.error
+        val emailError = (validationFailure as? CredentialsValidationError.Email)?.reason
+        val passwordError = when (validationFailure) {
+            is CredentialsValidationError.Email -> _state.value.passwordError
+            is CredentialsValidationError.Password -> validationFailure.reason
+            null -> null
+        }
         _state.update {
-            it.copy(email = email, emailError = emailError, isCredentialsValid = isCredentialsValid)
+            it.copy(
+                email = email,
+                emailError = emailError,
+                passwordError = passwordError,
+                isCredentialsValid = isCredentialsValid,
+            )
         }
     }
 
@@ -98,9 +107,12 @@ class SignupViewModel @Inject constructor(
             Credentials(Email(currentEmail), Password(password)),
         )
         val isCredentialsValid = validationResult is ResultWithError.Success
-        val passwordError = (validationResult as? ResultWithError.Failure)
-            ?.let { it.error as? CredentialsValidationError.Password }
-            ?.reason
+        val validationFailure = (validationResult as? ResultWithError.Failure)?.error
+        val passwordError = when (validationFailure) {
+            is CredentialsValidationError.Password -> validationFailure.reason
+            is CredentialsValidationError.Email -> _state.value.passwordError
+            null -> null
+        }
         val currentConfirmPassword = _state.value.confirmPassword
         val isPasswordConfirmed = password == currentConfirmPassword
         _state.update {

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt
@@ -118,4 +118,37 @@ class CredentialsValidatorImplTest {
         val result = validator.validate(credentials(password = maxPassword))
         assertIs<Success<Unit, *>>(result)
     }
+
+    @Test
+    fun `validate email alone returns success for valid email`() = runTest {
+        val result = validator.validate(Email("user@example.com"))
+        assertIs<Success<Unit, *>>(result)
+    }
+
+    @Test
+    fun `validate email alone returns error for invalid email`() = runTest {
+        val result = validator.validate(Email("notanemail"))
+        val failure = assertIs<Failure<*, EmailValidationError>>(result)
+        assertIs<EmailValidationError.NoAtInEmail>(failure.error)
+    }
+
+    @Test
+    fun `validate password alone returns success for valid password`() = runTest {
+        val result = validator.validate(Password("Password1"))
+        assertIs<Success<Unit, *>>(result)
+    }
+
+    @Test
+    fun `validate password alone returns error for invalid password`() = runTest {
+        val result = validator.validate(Password("short"))
+        val failure = assertIs<Failure<*, PasswordValidationError>>(result)
+        assertIs<PasswordValidationError.PasswordTooShort>(failure.error)
+    }
+
+    @Test
+    fun `validate password alone returns error regardless of email validity`() = runTest {
+        val result = validator.validate(Password("bad"))
+        val failure = assertIs<Failure<*, PasswordValidationError>>(result)
+        assertIs<PasswordValidationError.PasswordTooShort>(failure.error)
+    }
 }

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt
@@ -144,11 +144,4 @@ class CredentialsValidatorImplTest {
         val failure = assertIs<Failure<*, PasswordValidationError>>(result)
         assertIs<PasswordValidationError.PasswordTooShort>(failure.error)
     }
-
-    @Test
-    fun `validate password alone returns error regardless of email validity`() = runTest {
-        val result = validator.validate(Password("bad"))
-        val failure = assertIs<Failure<*, PasswordValidationError>>(result)
-        assertIs<PasswordValidationError.PasswordTooShort>(failure.error)
-    }
 }

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
@@ -1,0 +1,90 @@
+package timur.gilfanov.messenger.auth.ui
+
+import app.cash.turbine.test
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import timur.gilfanov.messenger.annotations.Component
+import timur.gilfanov.messenger.auth.ui.LoginViewModelTestFixtures.createViewModel
+import timur.gilfanov.messenger.domain.usecase.auth.repository.EmailValidationError
+import timur.gilfanov.messenger.domain.usecase.auth.repository.PasswordValidationError
+import timur.gilfanov.messenger.testutil.MainDispatcherRule
+
+private const val VALID_EMAIL = "user@example.com"
+private const val INVALID_EMAIL = "notanemail"
+private const val VALID_PASSWORD = "password1"
+private const val INVALID_SHORT_PASSWORD = "short"
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Category(Component::class)
+class LoginViewModelRealTimeValidationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `initial state has no email error`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.emailError)
+        }
+    }
+
+    @Test
+    fun `entering invalid email sets emailError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(INVALID_EMAIL)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<EmailValidationError>(state.emailError)
+        }
+    }
+
+    @Test
+    fun `fixing invalid email clears emailError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(INVALID_EMAIL)
+        viewModel.updateEmail(VALID_EMAIL)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.emailError)
+        }
+    }
+
+    @Test
+    fun `entering invalid password sets passwordError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<PasswordValidationError.PasswordTooShort>(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `fixing invalid password clears passwordError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+        viewModel.updatePassword(VALID_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
+        }
+    }
+}

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
@@ -37,6 +37,16 @@ class LoginViewModelRealTimeValidationTest {
     }
 
     @Test
+    fun `initial state has no password error`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
+        }
+    }
+
+    @Test
     fun `entering invalid email sets emailError`() = runTest {
         val viewModel = createViewModel()
 
@@ -85,6 +95,37 @@ class LoginViewModelRealTimeValidationTest {
         viewModel.state.test {
             val state = awaitItem()
             assertNull(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `updating password while email is invalid preserves existing passwordError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+        viewModel.updateEmail(INVALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<PasswordValidationError.PasswordTooShort>(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `fixing email reveals passwordError obscured by invalid email`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+        viewModel.updatePassword(VALID_PASSWORD)
+        viewModel.updateEmail(INVALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+        viewModel.updateEmail(VALID_EMAIL)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<PasswordValidationError.PasswordTooShort>(state.passwordError)
         }
     }
 }

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
@@ -99,6 +99,33 @@ class LoginViewModelRealTimeValidationTest {
     }
 
     @Test
+    fun `updating email to valid does not trigger passwordError on untouched password`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `fixing password while email is invalid clears passwordError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+        viewModel.updateEmail(INVALID_EMAIL)
+        viewModel.updatePassword(VALID_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
+        }
+    }
+
+    @Test
     fun `updating password while email is invalid preserves existing passwordError`() = runTest {
         val viewModel = createViewModel()
 

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
@@ -126,11 +126,9 @@ class LoginViewModelRealTimeValidationTest {
     }
 
     @Test
-    fun `updating to invalid password while email is invalid sets passwordError`() = runTest {
+    fun `invalid password sets passwordError even when email is invalid`() = runTest {
         val viewModel = createViewModel()
 
-        viewModel.updateEmail(VALID_EMAIL)
-        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
         viewModel.updateEmail(INVALID_EMAIL)
         viewModel.updatePassword(INVALID_SHORT_PASSWORD)
 

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
@@ -126,7 +126,7 @@ class LoginViewModelRealTimeValidationTest {
     }
 
     @Test
-    fun `updating password while email is invalid preserves existing passwordError`() = runTest {
+    fun `updating to invalid password while email is invalid sets passwordError`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.updateEmail(VALID_EMAIL)
@@ -141,7 +141,7 @@ class LoginViewModelRealTimeValidationTest {
     }
 
     @Test
-    fun `fixing email reveals passwordError obscured by invalid email`() = runTest {
+    fun `fixing email do not hide passwordError`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.updateEmail(VALID_EMAIL)

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
@@ -135,11 +135,9 @@ class SignupViewModelRealTimeValidationTest {
     }
 
     @Test
-    fun `updating to invalid password while email is invalid sets passwordError`() = runTest {
-        val viewModel = createViewModel()
+    fun `invalid password sets passwordError even when email is invalid`() = runTest {
+        val viewModel = LoginViewModelTestFixtures.createViewModel()
 
-        viewModel.updateEmail(VALID_EMAIL)
-        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
         viewModel.updateEmail(INVALID_EMAIL)
         viewModel.updatePassword(INVALID_SHORT_PASSWORD)
 

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
@@ -135,7 +135,7 @@ class SignupViewModelRealTimeValidationTest {
     }
 
     @Test
-    fun `updating password while email is invalid preserves existing passwordError`() = runTest {
+    fun `updating to invalid password while email is invalid sets passwordError`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.updateEmail(VALID_EMAIL)
@@ -150,7 +150,7 @@ class SignupViewModelRealTimeValidationTest {
     }
 
     @Test
-    fun `fixing email reveals passwordError obscured by invalid email`() = runTest {
+    fun `fixing email do not hide passwordError`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.updateEmail(VALID_EMAIL)
@@ -167,7 +167,7 @@ class SignupViewModelRealTimeValidationTest {
 
     @Test
     fun `restored name from SavedStateHandle has no nameError before any edits`() = runTest {
-        val handle = SavedStateHandle(mapOf("name" to VALID_NAME, "email" to VALID_EMAIL))
+        val handle = SavedStateHandle(mapOf("name" to INVALID_BLANK_NAME, "email" to INVALID_EMAIL))
         val viewModel = createViewModel(savedStateHandle = handle)
 
         viewModel.state.test {

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
@@ -136,7 +136,7 @@ class SignupViewModelRealTimeValidationTest {
 
     @Test
     fun `invalid password sets passwordError even when email is invalid`() = runTest {
-        val viewModel = LoginViewModelTestFixtures.createViewModel()
+        val viewModel = createViewModel()
 
         viewModel.updateEmail(INVALID_EMAIL)
         viewModel.updatePassword(INVALID_SHORT_PASSWORD)

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
@@ -1,0 +1,121 @@
+package timur.gilfanov.messenger.auth.ui
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import timur.gilfanov.messenger.annotations.Component
+import timur.gilfanov.messenger.auth.ui.SignupViewModelTestFixtures.createViewModel
+import timur.gilfanov.messenger.domain.usecase.auth.repository.EmailValidationError
+import timur.gilfanov.messenger.domain.usecase.auth.repository.PasswordValidationError
+import timur.gilfanov.messenger.domain.usecase.auth.repository.ProfileNameValidationError
+import timur.gilfanov.messenger.testutil.MainDispatcherRule
+
+private const val VALID_NAME = "Alice"
+private const val INVALID_BLANK_NAME = "   "
+private const val VALID_EMAIL = "user@example.com"
+private const val INVALID_EMAIL = "notanemail"
+private const val VALID_PASSWORD = "password1"
+private const val INVALID_SHORT_PASSWORD = "short"
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Category(Component::class)
+class SignupViewModelRealTimeValidationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `entering invalid name sets nameError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateName(INVALID_BLANK_NAME)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<ProfileNameValidationError.LengthOutOfBounds>(state.nameError)
+        }
+    }
+
+    @Test
+    fun `fixing invalid name clears nameError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateName(INVALID_BLANK_NAME)
+        viewModel.updateName(VALID_NAME)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.nameError)
+        }
+    }
+
+    @Test
+    fun `entering invalid email sets emailError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(INVALID_EMAIL)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<EmailValidationError>(state.emailError)
+        }
+    }
+
+    @Test
+    fun `fixing invalid email clears emailError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(INVALID_EMAIL)
+        viewModel.updateEmail(VALID_EMAIL)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.emailError)
+        }
+    }
+
+    @Test
+    fun `entering invalid password sets passwordError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<PasswordValidationError.PasswordTooShort>(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `fixing invalid password clears passwordError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+        viewModel.updatePassword(VALID_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `restored name from SavedStateHandle has no nameError before any edits`() = runTest {
+        val handle = SavedStateHandle(mapOf("name" to VALID_NAME, "email" to VALID_EMAIL))
+        val viewModel = createViewModel(savedStateHandle = handle)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.nameError)
+            assertNull(state.emailError)
+        }
+    }
+}

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
@@ -108,6 +108,37 @@ class SignupViewModelRealTimeValidationTest {
     }
 
     @Test
+    fun `updating password while email is invalid preserves existing passwordError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+        viewModel.updateEmail(INVALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<PasswordValidationError.PasswordTooShort>(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `fixing email reveals passwordError obscured by invalid email`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+        viewModel.updatePassword(VALID_PASSWORD)
+        viewModel.updateEmail(INVALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+        viewModel.updateEmail(VALID_EMAIL)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<PasswordValidationError.PasswordTooShort>(state.passwordError)
+        }
+    }
+
+    @Test
     fun `restored name from SavedStateHandle has no nameError before any edits`() = runTest {
         val handle = SavedStateHandle(mapOf("name" to VALID_NAME, "email" to VALID_EMAIL))
         val viewModel = createViewModel(savedStateHandle = handle)

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
@@ -166,14 +166,35 @@ class SignupViewModelRealTimeValidationTest {
     }
 
     @Test
-    fun `restored name from SavedStateHandle has no nameError before any edits`() = runTest {
-        val handle = SavedStateHandle(mapOf("name" to INVALID_BLANK_NAME, "email" to INVALID_EMAIL))
+    fun `local name error restored from SavedStateHandle`() = runTest {
+        val handle = SavedStateHandle(mapOf("name" to INVALID_BLANK_NAME))
         val viewModel = createViewModel(savedStateHandle = handle)
 
         viewModel.state.test {
             val state = awaitItem()
-            assertNull(state.nameError)
-            assertNull(state.emailError)
+            assertIs<ProfileNameValidationError.LengthOutOfBounds>(state.nameError)
+        }
+    }
+
+    @Test
+    fun `local email error restored from SavedStateHandle`() = runTest {
+        val handle = SavedStateHandle(mapOf("email" to INVALID_EMAIL))
+        val viewModel = createViewModel(savedStateHandle = handle)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<EmailValidationError.NoAtInEmail>(state.emailError)
+        }
+    }
+
+    @Test
+    fun `local password error not restored from SavedStateHandle`() = runTest {
+        val handle = SavedStateHandle(mapOf("password" to INVALID_SHORT_PASSWORD))
+        val viewModel = createViewModel(savedStateHandle = handle)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
         }
     }
 }

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
@@ -108,6 +108,33 @@ class SignupViewModelRealTimeValidationTest {
     }
 
     @Test
+    fun `updating email to valid does not trigger passwordError on untouched password`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `fixing password while email is invalid clears passwordError`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(VALID_EMAIL)
+        viewModel.updatePassword(INVALID_SHORT_PASSWORD)
+        viewModel.updateEmail(INVALID_EMAIL)
+        viewModel.updatePassword(VALID_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
+        }
+    }
+
+    @Test
     fun `updating password while email is invalid preserves existing passwordError`() = runTest {
         val viewModel = createViewModel()
 

--- a/feature/auth/src/testFixtures/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorStub.kt
+++ b/feature/auth/src/testFixtures/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorStub.kt
@@ -2,6 +2,10 @@ package timur.gilfanov.messenger.auth.domain.validation
 
 import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.auth.Credentials
+import timur.gilfanov.messenger.domain.entity.auth.Email
+import timur.gilfanov.messenger.domain.entity.auth.Password
+import timur.gilfanov.messenger.domain.usecase.auth.repository.EmailValidationError
+import timur.gilfanov.messenger.domain.usecase.auth.repository.PasswordValidationError
 
 class CredentialsValidatorStub(var error: CredentialsValidationError? = null) :
     CredentialsValidator {
@@ -16,4 +20,16 @@ class CredentialsValidatorStub(var error: CredentialsValidationError? = null) :
             ResultWithError.Failure(localError)
         }
     }
+
+    override fun validate(email: Email): ResultWithError<Unit, EmailValidationError> =
+        when (val e = error) {
+            is CredentialsValidationError.Email -> ResultWithError.Failure(e.reason)
+            else -> ResultWithError.Success(Unit)
+        }
+
+    override fun validate(password: Password): ResultWithError<Unit, PasswordValidationError> =
+        when (val e = error) {
+            is CredentialsValidationError.Password -> ResultWithError.Failure(e.reason)
+            else -> ResultWithError.Success(Unit)
+        }
 }


### PR DESCRIPTION
Closes #321

## Summary
Adds real-time field validation to Login and Signup screens so users see inline errors as they type, rather than only on form submission.

## Changes
- `LoginViewModel`: validates email and password on every field update; stores per-field error state and exposes it via `UiState`
- `SignupViewModel`: validates email, password, confirm password, and profile name on every field update; `updateEmail` now recalculates `passwordError` when the email field becomes valid
- Unit tests: `LoginViewModelRealTimeValidationTest` and `SignupViewModelRealTimeValidationTest` cover real-time validation state transitions

## Important Design Decision
Reuses existing `CredentialsValidator` and `ProfileNameValidator` interfaces — no validation rules duplicated in ViewModels. Real-time validation is additive: submit-time validation still runs.

## Testing
- [x] Unit tests added (`LoginViewModelRealTimeValidationTest`, `SignupViewModelRealTimeValidationTest`)
- [x] Manually tested
- [x] Edge cases considered (error clears as soon as field becomes valid, password/confirm-password cross-field dependency)

## Screenshots / Demo
N/A — logic-only change; no UI layout modifications.

## Acceptance criteria
- [x] Email field shows an inline error when the value is invalid and the field has been edited
- [x] Password field shows an inline error when the value is invalid and the field has been edited
- [x] Confirm password field shows an inline error when it does not match the password field
- [x] Profile name field shows an inline error when the value is invalid and the field has been edited
- [x] Errors clear as soon as the field becomes valid
- [x] Submit-time validation still runs (real-time validation is additive, not a replacement)
- [x] ViewModel unit tests cover the real-time validation state transitions

## Breaking Changes
None.

## Follow-ups
- [ ]