### PR TITLE
feat: validate that password is not equal to email

### DIFF
--- a/.ralphex/.gitignore
+++ b/.ralphex/.gitignore
@@ -1,2 +1,3 @@
+.gitignore
 progress/
 worktrees/

--- a/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/PasswordValidationError.kt
+++ b/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/PasswordValidationError.kt
@@ -1,11 +1,11 @@
 package timur.gilfanov.messenger.domain.usecase.auth.repository
 
 /**
- * Server-side password validation errors returned by auth operations.
+ * Password validation errors used in auth operations.
  *
- * Used as a detail type within repository error variants (e.g., [SignupRepositoryError.InvalidPassword])
- * to describe why the password was rejected.
- * These are display-only — use cases branch on the parent repository error variant,
+ * Covers both server-side rejections (e.g., [SignupRepositoryError.InvalidPassword])
+ * and client-side cross-field rules (e.g., [PasswordEqualToEmail]).
+ * These are display-only — callers branch on the parent error variant,
  * not on the sub-type.
  */
 sealed interface PasswordValidationError {

--- a/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/PasswordValidationError.kt
+++ b/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/PasswordValidationError.kt
@@ -15,4 +15,5 @@ sealed interface PasswordValidationError {
     data class PasswordMustContainNumbers(val minNumbers: Int) : PasswordValidationError
     data class PasswordMustContainAlphabet(val minAlphabet: Int) : PasswordValidationError
     data class UnknownRuleViolation(val reason: String) : PasswordValidationError
+    data object PasswordEqualToEmail : PasswordValidationError
 }

--- a/docs/plans/2026-04-22-validate-password-not-equal-to-email.md
+++ b/docs/plans/2026-04-22-validate-password-not-equal-to-email.md
@@ -45,11 +45,11 @@ Add a cross-field validation rule to `CredentialsValidatorImpl` that rejects pas
 - Modify: `feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImpl.kt`
 - Modify: `feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt`
 
-- [ ] In `validate(credentials: Credentials)`, after the existing password check succeeds, add: if `credentials.password.value == credentials.email.value` return `Failure(CredentialsValidationError.Password(PasswordValidationError.PasswordEqualToEmail))`
-- [ ] Add test: `password equal to email returns PasswordEqualToEmail`
-- [ ] Add test: `password different from email passes` (confirm the happy-path control, email=`"user@example.com"`, password=`"user@example.com1"` returns success)
-- [ ] Run `./gradlew ktlintFormat detekt --auto-correct`
-- [ ] Run `./gradlew :feature:auth:testDebugUnitTest --tests "timur.gilfanov.messenger.auth.domain.validation.CredentialsValidatorImplTest"` — must pass
+- [x] In `validate(credentials: Credentials)`, after the existing password check succeeds, add: if `credentials.password.value == credentials.email.value` return `Failure(CredentialsValidationError.Password(PasswordValidationError.PasswordEqualToEmail))`
+- [x] Add test: `password equal to email returns PasswordEqualToEmail`
+- [x] Add test: `password different from email passes` (confirm the happy-path control, email=`"user@example.com"`, password=`"user@example.com1"` returns success)
+- [x] Run `./gradlew ktlintFormat detekt --auto-correct`
+- [x] Run `./gradlew :feature:auth:testDebugUnitTest --tests "timur.gilfanov.messenger.auth.domain.validation.CredentialsValidatorImplTest"` — must pass
 
 ### Task 3: Verify acceptance criteria
 

--- a/docs/plans/2026-04-22-validate-password-not-equal-to-email.md
+++ b/docs/plans/2026-04-22-validate-password-not-equal-to-email.md
@@ -1,0 +1,62 @@
+---
+# feat: Validate Password Not Equal to Email (#328)
+
+## Overview
+Add a cross-field validation rule to `CredentialsValidatorImpl` that rejects passwords identical to the email address. Involves adding a new `PasswordEqualToEmail` error case to the domain model, wiring it into the validator, mapping it to a display string, and adding string resources.
+
+## Context
+- Files involved:
+  - `core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/PasswordValidationError.kt`
+  - `feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImpl.kt`
+  - `feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/utils/DisplayStrings.kt`
+  - `feature/auth/src/main/res/values/strings.xml`
+  - `feature/auth/src/main/res/values-de/strings.xml`
+  - `feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt`
+- Related patterns: Validation Pattern in CLAUDE.md; `2026-04-06-real-time-field-validation-login-signup.md` for task structure
+- Dependencies: none
+
+## Development Approach
+- **Testing approach**: Regular (code first, then tests)
+- Complete each task fully before moving to the next
+- **CRITICAL: every task MUST include new/updated tests**
+- **CRITICAL: all tests must pass before starting next task**
+
+## Implementation Steps
+
+### Task 1: Add error case, display string, and string resources
+
+**Files:**
+- Modify: `core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/auth/repository/PasswordValidationError.kt`
+- Modify: `feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/utils/DisplayStrings.kt`
+- Modify: `feature/auth/src/main/res/values/strings.xml`
+- Modify: `feature/auth/src/main/res/values-de/strings.xml`
+
+- [x] Add `data object PasswordEqualToEmail : PasswordValidationError` to the sealed interface
+- [x] Add `is PasswordValidationError.PasswordEqualToEmail -> stringResource(R.string.auth_error_password_must_not_equal_email)` branch to `PasswordValidationError.toDisplayString()` in `DisplayStrings.kt`
+- [x] Add `<string name="auth_error_password_must_not_equal_email">Password must not be the same as your email</string>` to `values/strings.xml`
+- [x] Add German translation `<string name="auth_error_password_must_not_equal_email">Passwort darf nicht mit der E-Mail-Adresse übereinstimmen</string>` to `values-de/strings.xml`
+- [x] Run `./gradlew ktlintFormat detekt --auto-correct`
+- [x] Run `./gradlew :feature:auth:testDebugUnitTest` to confirm no regressions from the new sealed case (exhaustive `when` in `DisplayStrings` will be checked at compile time via `compileMockDebugAndroidTestKotlin`)
+- [x] Run `./gradlew :app:compileMockDebugAndroidTestKotlin` to verify exhaustive `when` coverage across all modules
+
+### Task 2: Add validation logic and tests
+
+**Files:**
+- Modify: `feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImpl.kt`
+- Modify: `feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt`
+
+- [ ] In `validate(credentials: Credentials)`, after the existing password check succeeds, add: if `credentials.password.value == credentials.email.value` return `Failure(CredentialsValidationError.Password(PasswordValidationError.PasswordEqualToEmail))`
+- [ ] Add test: `password equal to email returns PasswordEqualToEmail`
+- [ ] Add test: `password different from email passes` (confirm the happy-path control, email=`"user@example.com"`, password=`"user@example.com1"` returns success)
+- [ ] Run `./gradlew ktlintFormat detekt --auto-correct`
+- [ ] Run `./gradlew :feature:auth:testDebugUnitTest --tests "timur.gilfanov.messenger.auth.domain.validation.CredentialsValidatorImplTest"` — must pass
+
+### Task 3: Verify acceptance criteria
+
+- [ ] Run `./gradlew ktlintFormat detekt --auto-correct`
+- [ ] Run `./gradlew :feature:auth:testDebugUnitTest`
+- [ ] Run `./gradlew :app:compileMockDebugAndroidTestKotlin`
+
+### Task 4: Update documentation
+
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/completed/2026-04-22-validate-password-not-equal-to-email.md
+++ b/docs/plans/completed/2026-04-22-validate-password-not-equal-to-email.md
@@ -53,10 +53,10 @@ Add a cross-field validation rule to `CredentialsValidatorImpl` that rejects pas
 
 ### Task 3: Verify acceptance criteria
 
-- [ ] Run `./gradlew ktlintFormat detekt --auto-correct`
-- [ ] Run `./gradlew :feature:auth:testDebugUnitTest`
-- [ ] Run `./gradlew :app:compileMockDebugAndroidTestKotlin`
+- [x] Run `./gradlew ktlintFormat detekt --auto-correct`
+- [x] Run `./gradlew :feature:auth:testDebugUnitTest`
+- [x] Run `./gradlew :app:compileMockDebugAndroidTestKotlin`
 
 ### Task 4: Update documentation
 
-- [ ] Move this plan to `docs/plans/completed/`
+- [x] Move this plan to `docs/plans/completed/`

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImpl.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImpl.kt
@@ -28,7 +28,16 @@ class CredentialsValidatorImpl : CredentialsValidator {
         return when (val passwordResult = validate(credentials.password)) {
             is ResultWithError.Failure ->
                 ResultWithError.Failure(CredentialsValidationError.Password(passwordResult.error))
-            is ResultWithError.Success -> ResultWithError.Success(Unit)
+            is ResultWithError.Success ->
+                if (credentials.password.value == credentials.email.value) {
+                    ResultWithError.Failure(
+                        CredentialsValidationError.Password(
+                            PasswordValidationError.PasswordEqualToEmail,
+                        ),
+                    )
+                } else {
+                    ResultWithError.Success(Unit)
+                }
         }
     }
 

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImpl.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImpl.kt
@@ -29,7 +29,7 @@ class CredentialsValidatorImpl : CredentialsValidator {
             is ResultWithError.Failure ->
                 ResultWithError.Failure(CredentialsValidationError.Password(passwordResult.error))
             is ResultWithError.Success ->
-                if (credentials.password.value == credentials.email.value) {
+                if (credentials.password.value.equals(credentials.email.value, ignoreCase = true)) {
                     ResultWithError.Failure(
                         CredentialsValidationError.Password(
                             PasswordValidationError.PasswordEqualToEmail,

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
@@ -69,6 +69,7 @@ class LoginViewModel @Inject constructor(
                 Email(email),
             ) as? ResultWithError.Failure
             )?.error
+        // Password error depends on email via `PasswordError.PasswordEqualToEmail`
         val passwordError = when {
             currentPassword.isEmpty() -> _state.value.passwordError
             credError is CredentialsValidationError.Password -> credError.reason
@@ -96,6 +97,7 @@ class LoginViewModel @Inject constructor(
         )
         val isCredentialsValid = credentialsResult is ResultWithError.Success
         val credError = (credentialsResult as? ResultWithError.Failure)?.error
+        // Email check have a priority in credentials validation in `CredentialsValidatorImpl`
         val passwordError = when (credError) {
             is CredentialsValidationError.Password -> credError.reason
             else -> (

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/login/LoginViewModel.kt
@@ -15,6 +15,7 @@ import timur.gilfanov.messenger.auth.domain.usecase.GoogleLoginUseCaseError
 import timur.gilfanov.messenger.auth.domain.usecase.LoginUseCaseError
 import timur.gilfanov.messenger.auth.domain.usecase.LoginWithCredentialsUseCase
 import timur.gilfanov.messenger.auth.domain.usecase.LoginWithGoogleUseCase
+import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidationError
 import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidator
 import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.auth.Credentials
@@ -58,18 +59,31 @@ class LoginViewModel @Inject constructor(
     fun updateEmail(email: String) {
         savedStateHandle[KEY_EMAIL] = email
         val currentPassword = _state.value.password
-        val isCredentialsValid = credentialsValidator.validate(
+        val credentialsResult = credentialsValidator.validate(
             Credentials(Email(email), Password(currentPassword)),
-        ) is ResultWithError.Success
+        )
+        val isCredentialsValid = credentialsResult is ResultWithError.Success
+        val credError = (credentialsResult as? ResultWithError.Failure)?.error
         val emailError = (
             credentialsValidator.validate(
                 Email(email),
             ) as? ResultWithError.Failure
             )?.error
+        val passwordError = when {
+            currentPassword.isEmpty() -> _state.value.passwordError
+            credError is CredentialsValidationError.Password -> credError.reason
+            credentialsResult is ResultWithError.Success -> null
+            else -> (
+                credentialsValidator.validate(
+                    Password(currentPassword),
+                ) as? ResultWithError.Failure
+                )?.error
+        }
         _state.update {
             it.copy(
                 email = email,
                 emailError = emailError,
+                passwordError = passwordError,
                 isCredentialsValid = isCredentialsValid,
             )
         }
@@ -77,11 +91,19 @@ class LoginViewModel @Inject constructor(
 
     fun updatePassword(password: String) {
         val currentEmail = _state.value.email
-        val isCredentialsValid = credentialsValidator.validate(
+        val credentialsResult = credentialsValidator.validate(
             Credentials(Email(currentEmail), Password(password)),
-        ) is ResultWithError.Success
-        val passwordError =
-            (credentialsValidator.validate(Password(password)) as? ResultWithError.Failure)?.error
+        )
+        val isCredentialsValid = credentialsResult is ResultWithError.Success
+        val credError = (credentialsResult as? ResultWithError.Failure)?.error
+        val passwordError = when (credError) {
+            is CredentialsValidationError.Password -> credError.reason
+            else -> (
+                credentialsValidator.validate(
+                    Password(password),
+                ) as? ResultWithError.Failure
+                )?.error
+        }
         _state.update {
             it.copy(
                 password = password,

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
@@ -15,6 +15,7 @@ import timur.gilfanov.messenger.auth.domain.usecase.SignupWithCredentialsUseCase
 import timur.gilfanov.messenger.auth.domain.usecase.SignupWithCredentialsUseCaseError
 import timur.gilfanov.messenger.auth.domain.usecase.SignupWithGoogleUseCase
 import timur.gilfanov.messenger.auth.domain.usecase.SignupWithGoogleUseCaseError
+import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidationError
 import timur.gilfanov.messenger.auth.domain.validation.CredentialsValidator
 import timur.gilfanov.messenger.auth.domain.validation.ProfileNameValidator
 import timur.gilfanov.messenger.domain.entity.ResultWithError
@@ -86,18 +87,31 @@ class SignupViewModel @Inject constructor(
     fun updateEmail(email: String) {
         savedStateHandle[KEY_EMAIL] = email
         val currentPassword = _state.value.password
-        val isCredentialsValid = credentialsValidator.validate(
+        val credentialsResult = credentialsValidator.validate(
             Credentials(Email(email), Password(currentPassword)),
-        ) is ResultWithError.Success
+        )
+        val isCredentialsValid = credentialsResult is ResultWithError.Success
+        val credError = (credentialsResult as? ResultWithError.Failure)?.error
         val emailError = (
             credentialsValidator.validate(
                 Email(email),
             ) as? ResultWithError.Failure
             )?.error
+        val passwordError = when {
+            currentPassword.isEmpty() -> _state.value.passwordError
+            credError is CredentialsValidationError.Password -> credError.reason
+            credentialsResult is ResultWithError.Success -> null
+            else -> (
+                credentialsValidator.validate(
+                    Password(currentPassword),
+                ) as? ResultWithError.Failure
+                )?.error
+        }
         _state.update {
             it.copy(
                 email = email,
                 emailError = emailError,
+                passwordError = passwordError,
                 isCredentialsValid = isCredentialsValid,
             )
         }
@@ -105,11 +119,19 @@ class SignupViewModel @Inject constructor(
 
     fun updatePassword(password: String) {
         val currentEmail = _state.value.email
-        val isCredentialsValid = credentialsValidator.validate(
+        val credentialsResult = credentialsValidator.validate(
             Credentials(Email(currentEmail), Password(password)),
-        ) is ResultWithError.Success
-        val passwordError =
-            (credentialsValidator.validate(Password(password)) as? ResultWithError.Failure)?.error
+        )
+        val isCredentialsValid = credentialsResult is ResultWithError.Success
+        val credError = (credentialsResult as? ResultWithError.Failure)?.error
+        val passwordError = when (credError) {
+            is CredentialsValidationError.Password -> credError.reason
+            else -> (
+                credentialsValidator.validate(
+                    Password(password),
+                ) as? ResultWithError.Failure
+                )?.error
+        }
         val currentConfirmPassword = _state.value.confirmPassword
         val isPasswordConfirmed = password == currentConfirmPassword
         _state.update {

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/screen/signup/SignupViewModel.kt
@@ -97,6 +97,7 @@ class SignupViewModel @Inject constructor(
                 Email(email),
             ) as? ResultWithError.Failure
             )?.error
+        // Password error depends on email via `PasswordError.PasswordEqualToEmail`
         val passwordError = when {
             currentPassword.isEmpty() -> _state.value.passwordError
             credError is CredentialsValidationError.Password -> credError.reason
@@ -124,6 +125,7 @@ class SignupViewModel @Inject constructor(
         )
         val isCredentialsValid = credentialsResult is ResultWithError.Success
         val credError = (credentialsResult as? ResultWithError.Failure)?.error
+        // Email check have a priority in credentials validation in `CredentialsValidatorImpl`
         val passwordError = when (credError) {
             is CredentialsValidationError.Password -> credError.reason
             else -> (

--- a/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/utils/DisplayStrings.kt
+++ b/feature/auth/src/main/kotlin/timur/gilfanov/messenger/auth/ui/utils/DisplayStrings.kt
@@ -77,4 +77,7 @@ internal fun PasswordValidationError.toDisplayString(): String = when (this) {
 
     is PasswordValidationError.UnknownRuleViolation ->
         stringResource(R.string.auth_error_invalid_password_server)
+
+    is PasswordValidationError.PasswordEqualToEmail ->
+        stringResource(R.string.auth_error_password_must_not_equal_email)
 }

--- a/feature/auth/src/main/res/values-de/strings.xml
+++ b/feature/auth/src/main/res/values-de/strings.xml
@@ -16,6 +16,7 @@
     <string name="auth_error_password_too_short">Passwort muss mindestens %d Zeichen lang sein</string>
     <string name="auth_error_password_too_long">Passwort darf höchstens %d Zeichen lang sein</string>
     <string name="auth_error_forbidden_character_in_password">Zeichen \'%s\' ist im Passwort nicht erlaubt</string>
+    <string name="auth_error_password_must_not_equal_email">Passwort darf nicht mit der E-Mail-Adresse übereinstimmen</string>
     <plurals name="auth_error_password_must_contain_numbers">
         <item quantity="one">Passwort muss mindestens 1 Zahl enthalten</item>
         <item quantity="other">Passwort muss mindestens %d Zahlen enthalten</item>

--- a/feature/auth/src/main/res/values/strings.xml
+++ b/feature/auth/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="auth_error_password_too_short">Password must be at least %d characters</string>
     <string name="auth_error_password_too_long">Password must be at most %d characters</string>
     <string name="auth_error_forbidden_character_in_password">Character \'%s\' is not allowed in password</string>
+    <string name="auth_error_password_must_not_equal_email">Password must not be the same as your email</string>
     <plurals name="auth_error_password_must_contain_numbers">
         <item quantity="one">Password must contain at least 1 number</item>
         <item quantity="other">Password must contain at least %d numbers</item>

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt
@@ -161,4 +161,31 @@ class CredentialsValidatorImplTest {
         )
         assertIs<Success<Unit, *>>(result)
     }
+
+    @Test
+    fun `password fails standalone validation even when equal to email`() = runTest {
+        // "a@b.cd" is a valid email but only 6 chars — below MIN_PASSWORD_LENGTH
+        val result = validator.validate(
+            credentials(email = "a@b.cd", password = "a@b.cd"),
+        )
+        val failure = assertIs<Failure<*, CredentialsValidationError.Password>>(result)
+        assertIs<PasswordValidationError.PasswordTooShort>(failure.error.reason)
+    }
+
+    @Test
+    fun `invalid email takes priority over password equal to email`() = runTest {
+        val result = validator.validate(
+            credentials(email = "notanemail1", password = "notanemail1"),
+        )
+        val failure = assertIs<Failure<*, CredentialsValidationError.Email>>(result)
+        assertIs<EmailValidationError.NoAtInEmail>(failure.error.reason)
+    }
+
+    @Test
+    fun `password equal to email in different case passes`() = runTest {
+        val result = validator.validate(
+            credentials(email = "User1@Example.com", password = "user1@example.com"),
+        )
+        assertIs<Success<Unit, *>>(result)
+    }
 }

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt
@@ -144,4 +144,21 @@ class CredentialsValidatorImplTest {
         val failure = assertIs<Failure<*, PasswordValidationError>>(result)
         assertIs<PasswordValidationError.PasswordTooShort>(failure.error)
     }
+
+    @Test
+    fun `password equal to email returns PasswordEqualToEmail`() = runTest {
+        val result = validator.validate(
+            credentials(email = "user1@example.com", password = "user1@example.com"),
+        )
+        val failure = assertIs<Failure<*, CredentialsValidationError.Password>>(result)
+        assertIs<PasswordValidationError.PasswordEqualToEmail>(failure.error.reason)
+    }
+
+    @Test
+    fun `password different from email passes`() = runTest {
+        val result = validator.validate(
+            credentials(email = "user@example.com", password = "user@example.com1"),
+        )
+        assertIs<Success<Unit, *>>(result)
+    }
 }

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/domain/validation/CredentialsValidatorImplTest.kt
@@ -155,6 +155,15 @@ class CredentialsValidatorImplTest {
     }
 
     @Test
+    fun `password equal to email in different case returns PasswordEqualToEmail`() = runTest {
+        val result = validator.validate(
+            credentials(email = "User1@Example.com", password = "user1@example.com"),
+        )
+        val failure = assertIs<Failure<*, CredentialsValidationError.Password>>(result)
+        assertIs<PasswordValidationError.PasswordEqualToEmail>(failure.error.reason)
+    }
+
+    @Test
     fun `password different from email passes`() = runTest {
         val result = validator.validate(
             credentials(email = "user@example.com", password = "user@example.com1"),
@@ -179,13 +188,5 @@ class CredentialsValidatorImplTest {
         )
         val failure = assertIs<Failure<*, CredentialsValidationError.Email>>(result)
         assertIs<EmailValidationError.NoAtInEmail>(failure.error.reason)
-    }
-
-    @Test
-    fun `password equal to email in different case passes`() = runTest {
-        val result = validator.validate(
-            credentials(email = "User1@Example.com", password = "user1@example.com"),
-        )
-        assertIs<Success<Unit, *>>(result)
     }
 }

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/LoginViewModelRealTimeValidationTest.kt
@@ -18,6 +18,7 @@ private const val VALID_EMAIL = "user@example.com"
 private const val INVALID_EMAIL = "notanemail"
 private const val VALID_PASSWORD = "password1"
 private const val INVALID_SHORT_PASSWORD = "short"
+private const val EMAIL_VALID_AS_PASSWORD = "user1@example.com"
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Category(Component::class)
@@ -153,4 +154,73 @@ class LoginViewModelRealTimeValidationTest {
             assertIs<PasswordValidationError.PasswordTooShort>(state.passwordError)
         }
     }
+
+    @Test
+    fun `password equal to email sets PasswordEqualToEmail error`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updatePassword(EMAIL_VALID_AS_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<PasswordValidationError.PasswordEqualToEmail>(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `changing password to differ from email clears PasswordEqualToEmail error`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updatePassword(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updatePassword(VALID_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `updating email to match password sets PasswordEqualToEmail error`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updatePassword(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updateEmail(EMAIL_VALID_AS_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<PasswordValidationError.PasswordEqualToEmail>(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `updating email to differ from password clears PasswordEqualToEmail error`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updatePassword(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updateEmail(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updateEmail(VALID_EMAIL)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `changing email to invalid after PasswordEqualToEmail clears stale cross-field error`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.updateEmail(EMAIL_VALID_AS_PASSWORD)
+            viewModel.updatePassword(EMAIL_VALID_AS_PASSWORD)
+            viewModel.updateEmail(INVALID_EMAIL)
+
+            viewModel.state.test {
+                val state = awaitItem()
+                assertNull(state.passwordError)
+            }
+        }
 }

--- a/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
+++ b/feature/auth/src/test/kotlin/timur/gilfanov/messenger/auth/ui/SignupViewModelRealTimeValidationTest.kt
@@ -22,6 +22,7 @@ private const val VALID_EMAIL = "user@example.com"
 private const val INVALID_EMAIL = "notanemail"
 private const val VALID_PASSWORD = "password1"
 private const val INVALID_SHORT_PASSWORD = "short"
+private const val EMAIL_VALID_AS_PASSWORD = "user1@example.com"
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Category(Component::class)
@@ -162,6 +163,75 @@ class SignupViewModelRealTimeValidationTest {
             assertIs<PasswordValidationError.PasswordTooShort>(state.passwordError)
         }
     }
+
+    @Test
+    fun `password equal to email sets PasswordEqualToEmail error`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updatePassword(EMAIL_VALID_AS_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<PasswordValidationError.PasswordEqualToEmail>(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `changing password to differ from email clears PasswordEqualToEmail error`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateEmail(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updatePassword(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updatePassword(VALID_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `updating email to match password sets PasswordEqualToEmail error`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updatePassword(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updateEmail(EMAIL_VALID_AS_PASSWORD)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertIs<PasswordValidationError.PasswordEqualToEmail>(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `updating email to differ from password clears PasswordEqualToEmail error`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updatePassword(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updateEmail(EMAIL_VALID_AS_PASSWORD)
+        viewModel.updateEmail(VALID_EMAIL)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.passwordError)
+        }
+    }
+
+    @Test
+    fun `changing email to invalid after PasswordEqualToEmail clears stale cross-field error`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.updateEmail(EMAIL_VALID_AS_PASSWORD)
+            viewModel.updatePassword(EMAIL_VALID_AS_PASSWORD)
+            viewModel.updateEmail(INVALID_EMAIL)
+
+            viewModel.state.test {
+                val state = awaitItem()
+                assertNull(state.passwordError)
+            }
+        }
 
     @Test
     fun `local name error restored from SavedStateHandle`() = runTest {


### PR DESCRIPTION
Closes #328

## Summary
Adds a cross-field credentials validation rule that rejects passwords matching the entered email address, including the user-facing error string and localized German resource.

The equality check remains inside `CredentialsValidatorImpl` so credentials validation stays centralized in the feature domain validator. The check is performed after the existing password rules, preserving the current validation ordering while adding the cross-field rule requested by the issue.

## Changes
- Added `PasswordValidationError.PasswordEqualToEmail` and mapped it to auth display strings.
- Updated `CredentialsValidatorImpl` to run the password-equals-email check after existing password validation succeeds.
- Added and updated auth validator and real-time ViewModel tests for the new validation path.

## Testing
Validation recorded in the completed plan:
- [x] Unit tests added or updated
- [ ] Manually tested
- [x] Edge cases considered

Commands recorded as run:
- `./gradlew :feature:auth:testDebugUnitTest --tests "timur.gilfanov.messenger.auth.domain.validation.CredentialsValidatorImplTest"`