### PR TITLE
Replace UUID.randomUUID() with constants in ChatViewModel tests

### DIFF
--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelAuthTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelAuthTest.kt
@@ -30,17 +30,21 @@ class ChatViewModelAuthTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
+    private companion object {
+        private val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        private val TEST_CURRENT_USER_ID =
+            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+        private val TEST_OTHER_USER_ID =
+            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
+    }
+
     @Test
     fun `loads chat on init`() = runTest {
-        val chatId = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-        val currentUserId = ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
-        val otherUserId = ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
-
-        val chat = createTestChat(chatId, currentUserId, otherUserId)
+        val chat = createTestChat(TEST_CHAT_ID, TEST_CURRENT_USER_ID, TEST_OTHER_USER_ID)
         val repository = MessengerRepositoryFake(chat = chat, flowChat = flowOf(Success(chat)))
 
         val viewModel = ChatViewModel(
-            chatIdUuid = chatId.id,
+            chatIdUuid = TEST_CHAT_ID.id,
             savedStateHandle = SavedStateHandle(),
             sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl()),
             receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository),
@@ -53,7 +57,7 @@ class ChatViewModelAuthTest {
             while (state !is ChatUiState.Ready) {
                 state = awaitItem()
             }
-            assertEquals(chatId, state.id)
+            assertEquals(TEST_CHAT_ID, state.id)
             assertEquals("Direct Message", state.title)
         }
     }

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelAuthTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelAuthTest.kt
@@ -2,7 +2,6 @@ package timur.gilfanov.messenger.ui.screen.chat
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import java.util.UUID
 import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -12,8 +11,6 @@ import org.junit.Test
 import org.junit.experimental.categories.Category
 import timur.gilfanov.messenger.annotations.Component
 import timur.gilfanov.messenger.domain.entity.ResultWithError.Success
-import timur.gilfanov.messenger.domain.entity.chat.ChatId
-import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
 import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidatorImpl
 import timur.gilfanov.messenger.domain.usecase.chat.MarkMessagesAsReadUseCase
 import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
@@ -21,6 +18,9 @@ import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CHAT_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CURRENT_USER_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_OTHER_USER_ID
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -29,14 +29,6 @@ class ChatViewModelAuthTest {
 
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
-
-    private companion object {
-        private val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-        private val TEST_CURRENT_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
-        private val TEST_OTHER_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
-    }
 
     @Test
     fun `loads chat on init`() = runTest {

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt
@@ -2,7 +2,6 @@ package timur.gilfanov.messenger.ui.screen.chat
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -18,8 +17,6 @@ import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.ResultWithError.Failure
 import timur.gilfanov.messenger.domain.entity.ResultWithError.Success
 import timur.gilfanov.messenger.domain.entity.chat.Chat
-import timur.gilfanov.messenger.domain.entity.chat.ChatId
-import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
 import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidatorImpl
 import timur.gilfanov.messenger.domain.usecase.chat.MarkMessagesAsReadUseCase
 import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
@@ -32,6 +29,9 @@ import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFakeWithPaging
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CHAT_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CURRENT_USER_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_OTHER_USER_ID
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestMessage
 
@@ -41,14 +41,6 @@ class ChatViewModelErrorHandlingTest {
 
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
-
-    private companion object {
-        private val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-        private val TEST_CURRENT_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
-        private val TEST_OTHER_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
-    }
 
     @Test
     fun `No chat exists error propagates to UI state`() = runTest {

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt
@@ -42,10 +42,17 @@ class ChatViewModelErrorHandlingTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
+    private companion object {
+        private val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        private val TEST_CURRENT_USER_ID =
+            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+        private val TEST_OTHER_USER_ID =
+            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
+    }
+
     @Test
     fun `No chat exists error propagates to UI state`() = runTest {
-        val chatId = ChatId(UUID.randomUUID())
-        val currentUserId = ParticipantId(UUID.randomUUID())
+        val chatId = TEST_CHAT_ID
 
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesRepositoryError>>(
@@ -79,9 +86,9 @@ class ChatViewModelErrorHandlingTest {
 
     @Test
     fun `Network errors propagates to UI state`() = runTest {
-        val chatId = ChatId(UUID.randomUUID())
-        val currentUserId = ParticipantId(UUID.randomUUID())
-        val otherUserId = ParticipantId(UUID.randomUUID())
+        val chatId = TEST_CHAT_ID
+        val currentUserId = TEST_CURRENT_USER_ID
+        val otherUserId = TEST_OTHER_USER_ID
 
         val initialChat = createTestChat(chatId, currentUserId, otherUserId)
         val chatFlow =
@@ -131,8 +138,7 @@ class ChatViewModelErrorHandlingTest {
 
     @Test
     fun `Network not available in Loading state propagates to UI state `() = runTest {
-        val chatId = ChatId(UUID.randomUUID())
-        val currentUserId = ParticipantId(UUID.randomUUID())
+        val chatId = TEST_CHAT_ID
 
         val chatFlow =
             MutableStateFlow<ResultWithError<Chat, ReceiveChatUpdatesRepositoryError>>(
@@ -170,9 +176,9 @@ class ChatViewModelErrorHandlingTest {
 
     @Test
     fun `Chat recovers from transient errors`() = runTest {
-        val chatId = ChatId(UUID.randomUUID())
-        val currentUserId = ParticipantId(UUID.randomUUID())
-        val otherUserId = ParticipantId(UUID.randomUUID())
+        val chatId = TEST_CHAT_ID
+        val currentUserId = TEST_CURRENT_USER_ID
+        val otherUserId = TEST_OTHER_USER_ID
         val now = Instant.fromEpochMilliseconds(1000)
 
         val initialChat = createTestChat(chatId, currentUserId, otherUserId)

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelLoadingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelLoadingTest.kt
@@ -39,6 +39,14 @@ class ChatViewModelLoadingTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
+    private companion object {
+        private val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        private val TEST_CURRENT_USER_ID =
+            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+        private val TEST_OTHER_USER_ID =
+            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
+    }
+
     private data class ExpectedStateParams(
         val chatId: ChatId,
         val currentUserId: ParticipantId,
@@ -73,9 +81,9 @@ class ChatViewModelLoadingTest {
 
     @Test
     fun `loads chat successfully`() = runTest {
-        val chatId = ChatId(UUID.randomUUID())
-        val currentUserId = ParticipantId(UUID.randomUUID())
-        val otherUserId = ParticipantId(UUID.randomUUID())
+        val chatId = TEST_CHAT_ID
+        val currentUserId = TEST_CURRENT_USER_ID
+        val otherUserId = TEST_OTHER_USER_ID
         val now = Instant.fromEpochMilliseconds(1000)
         val createdAtUi = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(1000))
         val message = createTestMessage(currentUserId, "Hello!", joinedAt = now, createdAt = now)
@@ -119,9 +127,9 @@ class ChatViewModelLoadingTest {
 
     @Test
     fun `loads group chat successfully`() = runTest {
-        val chatId = ChatId(UUID.randomUUID())
-        val currentUserId = ParticipantId(UUID.randomUUID())
-        val otherUserId = ParticipantId(UUID.randomUUID())
+        val chatId = TEST_CHAT_ID
+        val currentUserId = TEST_CURRENT_USER_ID
+        val otherUserId = TEST_OTHER_USER_ID
 
         val chat = createTestChat(chatId, currentUserId, otherUserId, isOneToOne = false)
 
@@ -167,8 +175,7 @@ class ChatViewModelLoadingTest {
 
     @Test
     fun `handles chat loading error`() = runTest {
-        val chatId = ChatId(UUID.randomUUID())
-        val currentUserId = ParticipantId(UUID.randomUUID())
+        val chatId = TEST_CHAT_ID
 
         val repository = MessengerRepositoryFake(
             flowChat = flowOf(

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelLoadingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelLoadingTest.kt
@@ -5,7 +5,6 @@ import app.cash.turbine.test
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.time.Instant
 import kotlinx.collections.immutable.persistentListOf
@@ -29,6 +28,9 @@ import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CHAT_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CURRENT_USER_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_OTHER_USER_ID
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestMessage
 
@@ -38,14 +40,6 @@ class ChatViewModelLoadingTest {
 
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
-
-    private companion object {
-        private val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-        private val TEST_CURRENT_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
-        private val TEST_OTHER_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
-    }
 
     private data class ExpectedStateParams(
         val chatId: ChatId,

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelMessageSendingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelMessageSendingTest.kt
@@ -13,8 +13,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import timur.gilfanov.messenger.annotations.Component
-import timur.gilfanov.messenger.domain.entity.chat.ChatId
-import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
 import timur.gilfanov.messenger.domain.entity.message.DeliveryError
 import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus
 import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Sending
@@ -30,6 +28,9 @@ import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFakeWithStatusFlow
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CHAT_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CURRENT_USER_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_OTHER_USER_ID
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
@@ -40,11 +41,6 @@ class ChatViewModelMessageSendingTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     companion object {
-        private val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-        private val TEST_CURRENT_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
-        private val TEST_OTHER_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
         private val TEST_MESSAGE_ID_1 =
             MessageId(UUID.fromString("00000000-0000-0000-0000-000000000004"))
         private val TEST_INSTANT = Instant.fromEpochMilliseconds(1000)

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
@@ -1,6 +1,7 @@
 package timur.gilfanov.messenger.ui.screen.chat
 
 import androidx.paging.PagingData
+import java.util.UUID
 import kotlin.time.Instant
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -37,6 +38,12 @@ import timur.gilfanov.messenger.domain.usecase.message.MessageRepository
 import timur.gilfanov.messenger.domain.usecase.message.repository.SendMessageRepositoryError
 
 object ChatViewModelTestFixtures {
+
+    val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+    val TEST_CURRENT_USER_ID =
+        ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+    val TEST_OTHER_USER_ID =
+        ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
 
     fun createAuthenticatedRepository(): AuthRepositoryFake = AuthRepositoryFake(
         initialSession = AuthSession(

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTextInputTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTextInputTest.kt
@@ -31,13 +31,17 @@ class ChatViewModelTextInputTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
+    private companion object {
+        private val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        private val TEST_CURRENT_USER_ID =
+            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+        private val TEST_OTHER_USER_ID =
+            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
+    }
+
     @Test
     fun `text input clear Empty text validation error`() = runTest {
-        val chatId = ChatId(UUID.randomUUID())
-        val currentUserId = ParticipantId(UUID.randomUUID())
-        val otherUserId = ParticipantId(UUID.randomUUID())
-
-        val initialChat = createTestChat(chatId, currentUserId, otherUserId)
+        val initialChat = createTestChat(TEST_CHAT_ID, TEST_CURRENT_USER_ID, TEST_OTHER_USER_ID)
 
         val repository = MessengerRepositoryFake(chat = initialChat, flowSendMessage = flowOf())
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
@@ -46,7 +50,7 @@ class ChatViewModelTextInputTest {
         val getPagedMessagesUseCase = GetPagedMessagesUseCase(repository)
         val markMessagesAsReadUseCase = MarkMessagesAsReadUseCase(repository)
         val viewModel = ChatViewModel(
-            chatIdUuid = chatId.id,
+            chatIdUuid = TEST_CHAT_ID.id,
             savedStateHandle = SavedStateHandle(),
             sendMessageUseCase = sendMessageUseCase,
             receiveChatUpdatesUseCase = receiveChatUpdatesUseCase,

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTextInputTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTextInputTest.kt
@@ -2,7 +2,6 @@ package timur.gilfanov.messenger.ui.screen.chat
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import java.util.UUID
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -12,8 +11,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import timur.gilfanov.messenger.annotations.Component
-import timur.gilfanov.messenger.domain.entity.chat.ChatId
-import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
 import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidatorImpl
 import timur.gilfanov.messenger.domain.entity.message.validation.TextValidationError
 import timur.gilfanov.messenger.domain.usecase.chat.MarkMessagesAsReadUseCase
@@ -22,6 +19,9 @@ import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CHAT_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CURRENT_USER_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_OTHER_USER_ID
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -30,14 +30,6 @@ class ChatViewModelTextInputTest {
 
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
-
-    private companion object {
-        private val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-        private val TEST_CURRENT_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
-        private val TEST_OTHER_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
-    }
 
     @Test
     fun `text input clear Empty text validation error`() = runTest {

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt
@@ -43,12 +43,22 @@ class ChatViewModelUpdatesTest {
 
     private val testDispatcher: TestDispatcher get() = mainDispatcherRule.testDispatcher
 
+    private companion object {
+        private val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        private val TEST_CURRENT_USER_ID =
+            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+        private val TEST_OTHER_USER_ID =
+            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
+        private val TEST_NEW_PARTICIPANT_ID =
+            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000004"))
+    }
+
     @Test
     @Ignore("Receiving messages from PagingData not implemented yet")
     fun `message from other participant appears in UI state`() = runTest {
-        val chatId = ChatId(UUID.randomUUID())
-        val currentUserId = ParticipantId(UUID.randomUUID())
-        val otherUserId = ParticipantId(UUID.randomUUID())
+        val chatId = TEST_CHAT_ID
+        val currentUserId = TEST_CURRENT_USER_ID
+        val otherUserId = TEST_OTHER_USER_ID
         val now = Instant.fromEpochMilliseconds(1000)
 
         val initialChat = createTestChat(chatId, currentUserId, otherUserId)
@@ -100,10 +110,10 @@ class ChatViewModelUpdatesTest {
 
     @Test
     fun `chat metadata updates seen in UI state`() = runTest {
-        val chatId = ChatId(UUID.randomUUID())
-        val currentUserId = ParticipantId(UUID.randomUUID())
-        val otherUserId = ParticipantId(UUID.randomUUID())
-        val newParticipantId = ParticipantId(UUID.randomUUID())
+        val chatId = TEST_CHAT_ID
+        val currentUserId = TEST_CURRENT_USER_ID
+        val otherUserId = TEST_OTHER_USER_ID
+        val newParticipantId = TEST_NEW_PARTICIPANT_ID
         val now = Instant.fromEpochMilliseconds(1000)
 
         val initialChat = createTestChat(chatId, currentUserId, otherUserId, isOneToOne = false)
@@ -168,9 +178,9 @@ class ChatViewModelUpdatesTest {
     @Ignore("Receiving messages from PagingData not implemented yet")
     @Test
     fun `few rapid messages result in one chat update`() = runTest {
-        val chatId = ChatId(UUID.randomUUID())
-        val currentUserId = ParticipantId(UUID.randomUUID())
-        val otherUserId = ParticipantId(UUID.randomUUID())
+        val chatId = TEST_CHAT_ID
+        val currentUserId = TEST_CURRENT_USER_ID
+        val otherUserId = TEST_OTHER_USER_ID
         val now = Instant.fromEpochMilliseconds(1000)
 
         val initialChat = createTestChat(chatId, currentUserId, otherUserId)

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt
@@ -19,7 +19,6 @@ import timur.gilfanov.messenger.annotations.Component
 import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.ResultWithError.Success
 import timur.gilfanov.messenger.domain.entity.chat.Chat
-import timur.gilfanov.messenger.domain.entity.chat.ChatId
 import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
 import timur.gilfanov.messenger.domain.entity.chat.buildParticipant
 import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidatorImpl
@@ -31,6 +30,9 @@ import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFakeWithPaging
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CHAT_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CURRENT_USER_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_OTHER_USER_ID
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestMessage
 
@@ -44,11 +46,6 @@ class ChatViewModelUpdatesTest {
     private val testDispatcher: TestDispatcher get() = mainDispatcherRule.testDispatcher
 
     private companion object {
-        private val TEST_CHAT_ID = ChatId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-        private val TEST_CURRENT_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
-        private val TEST_OTHER_USER_ID =
-            ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
         private val TEST_NEW_PARTICIPANT_ID =
             ParticipantId(UUID.fromString("00000000-0000-0000-0000-000000000004"))
     }

--- a/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
+++ b/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
@@ -48,9 +48,9 @@ Refactor five `ChatViewModel*Test` files in `app/src/test/.../ui/screen/chat/` t
 **Files:**
 - Modify: `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt`
 
-- [ ] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID`, `TEST_NEW_PARTICIPANT_ID` constants
-- [ ] Replace 10 `UUID.randomUUID()` call sites across 3 test methods with the constants
-- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelUpdatesTest"` — must pass before task 4
+- [x] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID`, `TEST_NEW_PARTICIPANT_ID` constants
+- [x] Replace 10 `UUID.randomUUID()` call sites across 3 test methods with the constants
+- [x] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelUpdatesTest"` — must pass before task 4
 
 ### Task 4: Refactor ChatViewModelAuthTest
 

--- a/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
+++ b/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
@@ -57,9 +57,9 @@ Refactor five `ChatViewModel*Test` files in `app/src/test/.../ui/screen/chat/` t
 **Files:**
 - Modify: `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelAuthTest.kt`
 
-- [ ] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID` constants (file already uses fixed `UUID.fromString` literals inline — just extract them)
-- [ ] Replace inline `UUID.fromString(...)` constructions in the test method with the constants
-- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelAuthTest"` — must pass before task 5
+- [x] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID` constants (file already uses fixed `UUID.fromString` literals inline — just extract them)
+- [x] Replace inline `UUID.fromString(...)` constructions in the test method with the constants
+- [x] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelAuthTest"` — must pass before task 5
 
 ### Task 5: Refactor ChatViewModelErrorHandlingTest
 

--- a/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
+++ b/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
@@ -1,0 +1,81 @@
+# Replace UUID.randomUUID() with constants in ChatViewModel test fixtures
+
+## Overview
+Refactor five `ChatViewModel*Test` files in `app/src/test/.../ui/screen/chat/` to replace `UUID.randomUUID()` calls with named companion-object constants (`TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID`, etc.). Resolves issue #337. Follows the existing convention already established in `ChatViewModelMessageSendingTest.kt` and `ChatViewModelProcessDeathTest.kt` for reproducibility per the project Testing Strategy.
+
+## Context
+- Files involved:
+  - `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt`
+  - `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTextInputTest.kt`
+  - `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelLoadingTest.kt`
+  - `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelAuthTest.kt` (already uses inline `UUID.fromString` — extract to constants)
+  - `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt` (added per Q&A — uses `UUID.randomUUID()`)
+- Related patterns:
+  - `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelMessageSendingTest.kt` — established companion-object constant pattern (lines 42-51)
+  - `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelProcessDeathTest.kt` — same pattern
+  - CLAUDE.md Testing rule: "Use constants for time and IDs instead of current time or randomly generated IDs"
+- Dependencies: none (pure test refactor)
+
+## Development Approach
+- Testing approach: refactor only — preserve existing test behavior; each test class already has tests. No new tests added; existing tests act as the regression check.
+- Each file is mechanically transformed: add a `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID` (and any extra IDs the file needs, e.g. `TEST_NEW_PARTICIPANT_ID` in UpdatesTest), then replace inline assignments inside test methods.
+- Use the same UUID literals as `ChatViewModelMessageSendingTest`: `00000000-0000-0000-0000-000000000001` (chat), `...000000002` (current user), `...000000003` (other user). Additional IDs continue the sequence (`...000000004`, etc.).
+- Remove `import java.util.UUID` only if no remaining usage in the file.
+- CRITICAL: existing tests must pass after each task before moving on.
+
+## Implementation Steps
+
+### Task 1: Refactor ChatViewModelLoadingTest
+
+**Files:**
+- Modify: `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelLoadingTest.kt`
+
+- [x] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID` constants using fixed UUID literals
+- [x] Replace 8 `UUID.randomUUID()` call sites across 3 test methods with the constants
+- [x] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelLoadingTest"` — must pass before task 2
+
+### Task 2: Refactor ChatViewModelTextInputTest
+
+**Files:**
+- Modify: `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTextInputTest.kt`
+
+- [ ] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID` constants
+- [ ] Replace 3 `UUID.randomUUID()` call sites with the constants
+- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTextInputTest"` — must pass before task 3
+
+### Task 3: Refactor ChatViewModelUpdatesTest
+
+**Files:**
+- Modify: `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelUpdatesTest.kt`
+
+- [ ] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID`, `TEST_NEW_PARTICIPANT_ID` constants
+- [ ] Replace 10 `UUID.randomUUID()` call sites across 3 test methods with the constants
+- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelUpdatesTest"` — must pass before task 4
+
+### Task 4: Refactor ChatViewModelAuthTest
+
+**Files:**
+- Modify: `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelAuthTest.kt`
+
+- [ ] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID` constants (file already uses fixed `UUID.fromString` literals inline — just extract them)
+- [ ] Replace inline `UUID.fromString(...)` constructions in the test method with the constants
+- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelAuthTest"` — must pass before task 5
+
+### Task 5: Refactor ChatViewModelErrorHandlingTest
+
+**Files:**
+- Modify: `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt`
+
+- [ ] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID` constants
+- [ ] Replace 11 `UUID.randomUUID()` call sites across 4 test methods with the constants
+- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelErrorHandlingTest"` — must pass before task 6
+
+### Task 6: Verify acceptance criteria
+
+- [ ] run `./gradlew ktlintFormat detekt --auto-correct`
+- [ ] run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.*"` to confirm all chat ViewModel tests pass together
+- [ ] verify no `UUID.randomUUID()` remains in the 5 refactored files via grep
+
+### Task 7: Update documentation
+
+- [ ] move this plan to `docs/plans/completed/`

--- a/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
+++ b/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
@@ -39,9 +39,9 @@ Refactor five `ChatViewModel*Test` files in `app/src/test/.../ui/screen/chat/` t
 **Files:**
 - Modify: `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTextInputTest.kt`
 
-- [ ] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID` constants
-- [ ] Replace 3 `UUID.randomUUID()` call sites with the constants
-- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTextInputTest"` — must pass before task 3
+- [x] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID` constants
+- [x] Replace 3 `UUID.randomUUID()` call sites with the constants
+- [x] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTextInputTest"` — must pass before task 3
 
 ### Task 3: Refactor ChatViewModelUpdatesTest
 

--- a/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
+++ b/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
@@ -66,9 +66,9 @@ Refactor five `ChatViewModel*Test` files in `app/src/test/.../ui/screen/chat/` t
 **Files:**
 - Modify: `app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelErrorHandlingTest.kt`
 
-- [ ] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID` constants
-- [ ] Replace 11 `UUID.randomUUID()` call sites across 4 test methods with the constants
-- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelErrorHandlingTest"` — must pass before task 6
+- [x] Add `private companion object` with `TEST_CHAT_ID`, `TEST_CURRENT_USER_ID`, `TEST_OTHER_USER_ID` constants
+- [x] Replace 11 `UUID.randomUUID()` call sites across 4 test methods with the constants
+- [x] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.ChatViewModelErrorHandlingTest"` — must pass before task 6
 
 ### Task 6: Verify acceptance criteria
 

--- a/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
+++ b/docs/plans/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
@@ -72,9 +72,9 @@ Refactor five `ChatViewModel*Test` files in `app/src/test/.../ui/screen/chat/` t
 
 ### Task 6: Verify acceptance criteria
 
-- [ ] run `./gradlew ktlintFormat detekt --auto-correct`
-- [ ] run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.*"` to confirm all chat ViewModel tests pass together
-- [ ] verify no `UUID.randomUUID()` remains in the 5 refactored files via grep
+- [x] run `./gradlew ktlintFormat detekt --auto-correct`
+- [x] run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.*"` to confirm all chat ViewModel tests pass together
+- [x] verify no `UUID.randomUUID()` remains in the 5 refactored files via grep
 
 ### Task 7: Update documentation
 

--- a/docs/plans/completed/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
+++ b/docs/plans/completed/2026-05-02-replace-uuid-randomuuid-in-chat-viewmodel-tests.md
@@ -78,4 +78,4 @@ Refactor five `ChatViewModel*Test` files in `app/src/test/.../ui/screen/chat/` t
 
 ### Task 7: Update documentation
 
-- [ ] move this plan to `docs/plans/completed/`
+- [x] move this plan to `docs/plans/completed/`


### PR DESCRIPTION
Closes #337

## Summary
Replace random UUID generation in ChatViewModel test fixtures with named constants so test input IDs are deterministic and easier to reproduce.

## Changes
- Added stable UUID constants to ChatViewModel auth, loading, text input, update, and error handling tests.
- Replaced inline `UUID.randomUUID()` and repeated inline UUID construction with fixture constants.
- Moved the completed implementation plan into `docs/plans/completed/`.

## Important Design Decision
No architecture changes. This keeps the existing test fixture structure and only makes generated IDs deterministic.

## Testing
- [x] Unit tests added or updated
- [ ] Manually tested
- [ ] Edge cases considered

## Screenshots / Demo
Not applicable; test-only change.

## Acceptance criteria
- [ ] ChatViewModel test IDs are named constants such as `TEST_CHAT_ID`, `TEST_PARTICIPANT_ID`, and `TEST_CURRENT_USER_ID`.
- [ ] IDs are defined in fixture or companion object scope and reused consistently across affected tests.
- [ ] Test runs no longer generate different participant or chat IDs through `UUID.randomUUID()` in the affected fixtures.

## Breaking Changes
None.

## Follow-ups
- [ ] None.