### PR TITLE
Clean up orphaned participants on chat deletion

### DIFF
--- a/app/src/main/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImpl.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImpl.kt
@@ -99,6 +99,7 @@ class LocalChatDataSourceImpl @Inject constructor(
                 val chatEntity = chatDao.getChatById(chatId.id.toString())
                 if (chatEntity != null) {
                     chatDao.deleteChat(chatEntity)
+                    participantDao.deleteOrphanedParticipants()
                     ResultWithError.Success(Unit)
                 } else {
                     ResultWithError.Failure(

--- a/app/src/main/java/timur/gilfanov/messenger/data/source/local/LocalSyncDataSourceImpl.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/data/source/local/LocalSyncDataSourceImpl.kt
@@ -189,6 +189,9 @@ class LocalSyncDataSourceImpl @Inject constructor(
 
     private suspend fun applyChatDeletedDelta(delta: ChatDeletedDelta) {
         val chatEntity = chatDao.getChatById(delta.chatId.id.toString())
-        chatEntity?.let { chatDao.deleteChat(it) }
+        chatEntity?.let {
+            chatDao.deleteChat(it)
+            participantDao.deleteOrphanedParticipants()
+        }
     }
 }

--- a/app/src/main/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDao.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDao.kt
@@ -32,7 +32,17 @@ interface ParticipantDao {
     suspend fun deleteParticipantById(participantId: String)
 
     @Query(
-        "DELETE FROM participants WHERE id NOT IN (SELECT participantId FROM chat_participants)",
+        """
+        DELETE FROM participants
+        WHERE NOT EXISTS (
+            SELECT 1 FROM chat_participants
+            WHERE chat_participants.participantId = participants.id
+        )
+        AND NOT EXISTS (
+            SELECT 1 FROM messages
+            WHERE messages.senderId = participants.id
+        )
+        """,
     )
     suspend fun deleteOrphanedParticipants(): Int
 

--- a/app/src/main/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDao.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDao.kt
@@ -31,6 +31,11 @@ interface ParticipantDao {
     @Query("DELETE FROM participants WHERE id = :participantId")
     suspend fun deleteParticipantById(participantId: String)
 
+    @Query(
+        "DELETE FROM participants WHERE id NOT IN (SELECT participantId FROM chat_participants)",
+    )
+    suspend fun deleteOrphanedParticipants(): Int
+
     @Query("SELECT * FROM participants WHERE id = :participantId")
     suspend fun getParticipantById(participantId: String): ParticipantEntity?
 

--- a/app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImplTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImplTest.kt
@@ -16,11 +16,13 @@ import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import timur.gilfanov.messenger.annotations.Component
+import timur.gilfanov.messenger.data.source.local.database.mapper.EntityMappers
 import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.chat.Chat
 import timur.gilfanov.messenger.domain.entity.chat.ChatId
 import timur.gilfanov.messenger.domain.entity.chat.ChatPreview
 import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
+import timur.gilfanov.messenger.domain.entity.message.MessageId
 import timur.gilfanov.messenger.domain.testutil.DomainTestFixtures
 import timur.gilfanov.messenger.domain.testutil.NoOpLogger
 import timur.gilfanov.messenger.testutil.InMemoryDatabaseRule
@@ -112,6 +114,131 @@ class LocalChatDataSourceImplTest {
         // Then
         assertIs<ResultWithError.Failure<Unit, LocalDataSourceError>>(result)
         assertIs<LocalDataSourceError.ChatNotFound>(result.error)
+    }
+
+    @Test
+    fun `delete non-existent chat does not touch participants`() = runTest {
+        // Given - existing chat with participants in the database
+        val chat = createTestChat()
+        localChatDataSource.insertChat(chat)
+        val participantsBefore = databaseRule.participantDao.getAllParticipants()
+        assertEquals(chat.participants.size, participantsBefore.size)
+
+        val nonExistentChatId = ChatId(UUID.fromString("99999999-9999-9999-9999-999999999999"))
+
+        // When
+        val result = localChatDataSource.deleteChat(nonExistentChatId)
+
+        // Then
+        assertIs<ResultWithError.Failure<Unit, LocalDataSourceError>>(result)
+        assertIs<LocalDataSourceError.ChatNotFound>(result.error)
+        val participantsAfter = databaseRule.participantDao.getAllParticipants()
+        assertEquals(participantsBefore.size, participantsAfter.size)
+    }
+
+    @Test
+    fun `delete chat cascades messages and chat_participants`() = runTest {
+        // Given - chat with messages and participants
+        val chat = createTestChat()
+        localChatDataSource.insertChat(chat)
+        val message = DomainTestFixtures.createTestTextMessage(
+            id = MessageId(UUID.fromString("33333333-cccc-cccc-cccc-cccccccccccc")),
+            text = "Hello",
+            sender = chat.participants.first(),
+            recipient = chat.id,
+            createdAt = Instant.fromEpochMilliseconds(1500000),
+        )
+        databaseRule.messageDao.insertMessage(
+            with(EntityMappers) { message.toMessageEntity() },
+        )
+
+        // Sanity-check the pre-state.
+        assertEquals(
+            1,
+            databaseRule.messageDao.getMessagesByChatId(chat.id.id.toString()).size,
+        )
+        assertEquals(
+            chat.participants.size,
+            databaseRule.participantDao.getParticipantsByChatId(chat.id.id.toString()).size,
+        )
+
+        // When
+        val result = localChatDataSource.deleteChat(chat.id)
+
+        // Then - FK cascade removed messages and junction rows
+        assertIs<ResultWithError.Success<Unit, LocalDataSourceError>>(result)
+        assertTrue(
+            databaseRule.messageDao.getMessagesByChatId(chat.id.id.toString()).isEmpty(),
+        )
+        assertTrue(
+            databaseRule.participantDao.getParticipantsByChatId(chat.id.id.toString()).isEmpty(),
+        )
+    }
+
+    @Test
+    fun `delete chat removes orphaned participants`() = runTest {
+        // Given - chat whose participants are not shared with any other chat
+        val chat = createTestChat()
+        localChatDataSource.insertChat(chat)
+        assertEquals(chat.participants.size, databaseRule.participantDao.getAllParticipants().size)
+
+        // When
+        val result = localChatDataSource.deleteChat(chat.id)
+
+        // Then - all participants removed because no other chat references them
+        assertIs<ResultWithError.Success<Unit, LocalDataSourceError>>(result)
+        assertTrue(databaseRule.participantDao.getAllParticipants().isEmpty())
+    }
+
+    @Test
+    fun `delete chat preserves participants shared with another chat`() = runTest {
+        // Given - two chats sharing the same participants
+        val sharedParticipants = setOf(
+            DomainTestFixtures.createTestParticipant(
+                id = ParticipantId(
+                    UUID.fromString("44444444-4444-4444-4444-444444444444"),
+                ),
+                name = "User 1",
+                joinedAt = Instant.fromEpochMilliseconds(1000000),
+                onlineAt = null,
+            ),
+            DomainTestFixtures.createTestParticipant(
+                id = ParticipantId(
+                    UUID.fromString("55555555-5555-5555-5555-555555555555"),
+                ),
+                name = "User 2",
+                joinedAt = Instant.fromEpochMilliseconds(1100000),
+                onlineAt = null,
+            ),
+        )
+        val chatToDelete = DomainTestFixtures.createTestChat(
+            id = ChatId(UUID.fromString("aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa")),
+            name = "Chat to Delete",
+            participants = sharedParticipants,
+        )
+        val chatToKeep = DomainTestFixtures.createTestChat(
+            id = ChatId(UUID.fromString("aaaaaaaa-2222-2222-2222-aaaaaaaaaaaa")),
+            name = "Chat to Keep",
+            participants = sharedParticipants,
+        )
+        localChatDataSource.insertChat(chatToDelete)
+        localChatDataSource.insertChat(chatToKeep)
+
+        // When
+        val result = localChatDataSource.deleteChat(chatToDelete.id)
+
+        // Then - shared participants stay because chatToKeep still references them
+        assertIs<ResultWithError.Success<Unit, LocalDataSourceError>>(result)
+        assertEquals(
+            sharedParticipants.size,
+            databaseRule.participantDao.getAllParticipants().size,
+        )
+        assertEquals(
+            sharedParticipants.size,
+            databaseRule.participantDao.getParticipantsByChatId(
+                chatToKeep.id.id.toString(),
+            ).size,
+        )
     }
 
     @Test

--- a/app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalSyncDataSourceImplTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalSyncDataSourceImplTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.time.Instant
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
@@ -226,6 +227,151 @@ class LocalSyncDataSourceImplTest {
         val storedChat = databaseRule.chatDao.getChatById(chatId.id.toString())
         assertNull(storedChat)
     }
+
+    @Test
+    fun `applyChatDelta with ChatDeletedDelta cascades messages and chat_participants`() = runTest {
+        // Given - chat with messages and participants
+        val chatId = ChatId(UUID.fromString("dddddddd-1111-1111-1111-dddddddddddd"))
+        val createDelta = ChatCreatedDelta(
+            chatId = chatId,
+            chatMetadata = ChatMetadata(
+                name = "Chat With Messages",
+                participants = createTestParticipants(),
+                pictureUrl = null,
+                rules = persistentSetOf<timur.gilfanov.messenger.domain.entity.chat.Rule>(),
+                unreadMessagesCount = 0,
+                lastReadMessageId = null,
+                lastActivityAt = null,
+            ),
+            initialMessages = createTestMessages(chatId),
+            timestamp = Instant.fromEpochMilliseconds(1000000),
+        )
+        localSyncDataSource.applyChatDelta(createDelta)
+
+        // Sanity-check the pre-state.
+        assertEquals(
+            1,
+            databaseRule.messageDao.getMessagesByChatId(chatId.id.toString()).size,
+        )
+        assertEquals(
+            2,
+            databaseRule.participantDao.getParticipantsByChatId(chatId.id.toString()).size,
+        )
+
+        // When
+        val deleteDelta = ChatDeletedDelta(
+            chatId = chatId,
+            timestamp = Instant.fromEpochMilliseconds(2000000),
+        )
+        val result = localSyncDataSource.applyChatDelta(deleteDelta)
+
+        // Then - FK cascade removed messages and junction rows
+        assertIs<ResultWithError.Success<Unit, LocalDataSourceError>>(result)
+        assertTrue(
+            databaseRule.messageDao.getMessagesByChatId(chatId.id.toString()).isEmpty(),
+        )
+        assertTrue(
+            databaseRule.participantDao.getParticipantsByChatId(chatId.id.toString()).isEmpty(),
+        )
+    }
+
+    @Test
+    fun `applyChatDelta with ChatDeletedDelta removes orphaned participants`() = runTest {
+        // Given - chat whose participants are not shared with any other chat
+        val chatId = ChatId(UUID.fromString("dddddddd-2222-2222-2222-dddddddddddd"))
+        val participants = createTestParticipants()
+        val createDelta = ChatCreatedDelta(
+            chatId = chatId,
+            chatMetadata = ChatMetadata(
+                name = "Solo Chat",
+                participants = participants,
+                pictureUrl = null,
+                rules = persistentSetOf<timur.gilfanov.messenger.domain.entity.chat.Rule>(),
+                unreadMessagesCount = 0,
+                lastReadMessageId = null,
+                lastActivityAt = null,
+            ),
+            initialMessages = persistentListOf(),
+            timestamp = Instant.fromEpochMilliseconds(1000000),
+        )
+        localSyncDataSource.applyChatDelta(createDelta)
+        assertEquals(participants.size, databaseRule.participantDao.getAllParticipants().size)
+
+        // When
+        val deleteDelta = ChatDeletedDelta(
+            chatId = chatId,
+            timestamp = Instant.fromEpochMilliseconds(2000000),
+        )
+        val result = localSyncDataSource.applyChatDelta(deleteDelta)
+
+        // Then - all participants removed because no other chat references them
+        assertIs<ResultWithError.Success<Unit, LocalDataSourceError>>(result)
+        assertTrue(databaseRule.participantDao.getAllParticipants().isEmpty())
+    }
+
+    @Test
+    fun `applyChatDelta with ChatDeletedDelta preserves participants shared with another chat`() =
+        runTest {
+            // Given - two chats sharing the same participants
+            val chatToDelete = ChatId(UUID.fromString("dddddddd-3333-3333-3333-dddddddddddd"))
+            val chatToKeep = ChatId(UUID.fromString("dddddddd-4444-4444-4444-dddddddddddd"))
+            val sharedParticipants = createTestParticipants()
+
+            localSyncDataSource.applyChatDelta(
+                ChatCreatedDelta(
+                    chatId = chatToDelete,
+                    chatMetadata = ChatMetadata(
+                        name = "Chat to Delete",
+                        participants = sharedParticipants,
+                        pictureUrl = null,
+                        rules = persistentSetOf<
+                            timur.gilfanov.messenger.domain.entity.chat.Rule,
+                            >(),
+                        unreadMessagesCount = 0,
+                        lastReadMessageId = null,
+                        lastActivityAt = null,
+                    ),
+                    initialMessages = persistentListOf(),
+                    timestamp = Instant.fromEpochMilliseconds(1000000),
+                ),
+            )
+            localSyncDataSource.applyChatDelta(
+                ChatCreatedDelta(
+                    chatId = chatToKeep,
+                    chatMetadata = ChatMetadata(
+                        name = "Chat to Keep",
+                        participants = sharedParticipants,
+                        pictureUrl = null,
+                        rules = persistentSetOf<
+                            timur.gilfanov.messenger.domain.entity.chat.Rule,
+                            >(),
+                        unreadMessagesCount = 0,
+                        lastReadMessageId = null,
+                        lastActivityAt = null,
+                    ),
+                    initialMessages = persistentListOf(),
+                    timestamp = Instant.fromEpochMilliseconds(1100000),
+                ),
+            )
+
+            // When
+            val deleteDelta = ChatDeletedDelta(
+                chatId = chatToDelete,
+                timestamp = Instant.fromEpochMilliseconds(2000000),
+            )
+            val result = localSyncDataSource.applyChatDelta(deleteDelta)
+
+            // Then - shared participants stay because chatToKeep still references them
+            assertIs<ResultWithError.Success<Unit, LocalDataSourceError>>(result)
+            assertEquals(
+                sharedParticipants.size,
+                databaseRule.participantDao.getAllParticipants().size,
+            )
+            assertEquals(
+                sharedParticipants.size,
+                databaseRule.participantDao.getParticipantsByChatId(chatToKeep.id.toString()).size,
+            )
+        }
 
     // Upsert behavior tests (Room uses OnConflictStrategy.REPLACE)
     @Test

--- a/app/src/test/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDaoTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDaoTest.kt
@@ -1,7 +1,6 @@
 package timur.gilfanov.messenger.data.source.local.database.dao
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -41,7 +40,7 @@ class ParticipantDaoTest {
     @Test
     fun `insert and get participant by id`() = runTest {
         // Given
-        val participantId = UUID.randomUUID().toString()
+        val participantId = PARTICIPANT_ID
         val participant = createTestParticipant(participantId)
 
         // When
@@ -57,8 +56,8 @@ class ParticipantDaoTest {
     @Test
     fun `insert multiple participants and get all`() = runTest {
         // Given
-        val participant1 = createTestParticipant(UUID.randomUUID().toString(), "User 1")
-        val participant2 = createTestParticipant(UUID.randomUUID().toString(), "User 2")
+        val participant1 = createTestParticipant(PARTICIPANT_ID, "User 1")
+        val participant2 = createTestParticipant(SECOND_PARTICIPANT_ID, "User 2")
         val participants = listOf(participant1, participant2)
 
         // When
@@ -74,7 +73,7 @@ class ParticipantDaoTest {
     @Test
     fun `update participant changes data through different methods`() = runTest {
         // Given
-        val participantId = UUID.randomUUID().toString()
+        val participantId = PARTICIPANT_ID
         val participant = createTestParticipant(participantId, "Original Name")
         val onlineTime = Instant.fromEpochMilliseconds(2000000)
 
@@ -114,7 +113,7 @@ class ParticipantDaoTest {
     @Test
     fun `delete participant removes from database`() = runTest {
         // Given
-        val participantId = UUID.randomUUID().toString()
+        val participantId = PARTICIPANT_ID
         val participant = createTestParticipant(participantId)
 
         // When
@@ -129,8 +128,8 @@ class ParticipantDaoTest {
     @Test
     fun `participant with admin role is properly stored via cross-reference`() = runTest {
         // Given
-        val participantId = UUID.randomUUID().toString()
-        val chatId = UUID.randomUUID().toString()
+        val participantId = PARTICIPANT_ID
+        val chatId = CHAT_ID
         val participant = createTestParticipant(participantId)
 
         // Create test chat first
@@ -173,8 +172,8 @@ class ParticipantDaoTest {
     @Test
     fun `participant with moderator role is properly stored via cross-reference`() = runTest {
         // Given
-        val participantId = UUID.randomUUID().toString()
-        val chatId = UUID.randomUUID().toString()
+        val participantId = PARTICIPANT_ID
+        val chatId = CHAT_ID
         val participant = createTestParticipant(participantId)
 
         // Create test chat first
@@ -217,9 +216,9 @@ class ParticipantDaoTest {
     @Test
     fun `deleteOrphanedParticipants returns zero when all participants are referenced`() = runTest {
         // Given - two participants, both linked to a chat
-        val participantA = createTestParticipant(UUID.randomUUID().toString(), "User A")
-        val participantB = createTestParticipant(UUID.randomUUID().toString(), "User B")
-        val chatId = UUID.randomUUID().toString()
+        val participantA = createTestParticipant(PARTICIPANT_ID, "User A")
+        val participantB = createTestParticipant(SECOND_PARTICIPANT_ID, "User B")
+        val chatId = CHAT_ID
         val chat = createTestChat(chatId)
         participantDao.insertParticipants(listOf(participantA, participantB))
         chatDao.insertChat(chat)
@@ -243,9 +242,9 @@ class ParticipantDaoTest {
     fun `deleteOrphanedParticipants removes participant whose only chat reference was deleted`() =
         runTest {
             // Given - participant linked to a chat, then the junction row is removed
-            val participantId = UUID.randomUUID().toString()
+            val participantId = PARTICIPANT_ID
             val participant = createTestParticipant(participantId)
-            val chatId = UUID.randomUUID().toString()
+            val chatId = CHAT_ID
             val chat = createTestChat(chatId)
             participantDao.insertParticipant(participant)
             chatDao.insertChat(chat)
@@ -264,12 +263,12 @@ class ParticipantDaoTest {
     fun `deleteOrphanedParticipants preserves participants still referenced by another chat`() =
         runTest {
             // Given - one participant in two chats, one chat is removed
-            val sharedParticipantId = UUID.randomUUID().toString()
-            val orphanParticipantId = UUID.randomUUID().toString()
+            val sharedParticipantId = PARTICIPANT_ID
+            val orphanParticipantId = SECOND_PARTICIPANT_ID
             val sharedParticipant = createTestParticipant(sharedParticipantId, "Shared")
             val orphanParticipant = createTestParticipant(orphanParticipantId, "Orphan")
-            val chatA = createTestChat(UUID.randomUUID().toString())
-            val chatB = createTestChat(UUID.randomUUID().toString())
+            val chatA = createTestChat(CHAT_ID)
+            val chatB = createTestChat(SECOND_CHAT_ID)
             participantDao.insertParticipants(listOf(sharedParticipant, orphanParticipant))
             chatDao.insertChat(chatA)
             chatDao.insertChat(chatB)
@@ -295,9 +294,9 @@ class ParticipantDaoTest {
     @Test
     fun `deleteOrphanedParticipants preserves participant still referenced by messages`() =
         runTest {
-            val participantId = "11111111-1111-1111-1111-111111111111"
-            val chatId = "22222222-2222-2222-2222-222222222222"
-            val messageId = "33333333-3333-3333-3333-333333333333"
+            val participantId = PARTICIPANT_ID
+            val chatId = CHAT_ID
+            val messageId = MESSAGE_ID
             val participant = createTestParticipant(participantId)
             val chat = createTestChat(chatId)
             val message = createTestMessage(messageId, chatId, participantId)
@@ -361,4 +360,12 @@ class ParticipantDaoTest {
         deliveryStatus = null,
         createdAt = Instant.fromEpochMilliseconds(1100000),
     )
+
+    private companion object {
+        const val PARTICIPANT_ID = "11111111-1111-1111-1111-111111111111"
+        const val SECOND_PARTICIPANT_ID = "22222222-2222-2222-2222-222222222222"
+        const val CHAT_ID = "33333333-3333-3333-3333-333333333333"
+        const val SECOND_CHAT_ID = "44444444-4444-4444-4444-444444444444"
+        const val MESSAGE_ID = "55555555-5555-5555-5555-555555555555"
+    }
 }

--- a/app/src/test/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDaoTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDaoTest.kt
@@ -16,6 +16,8 @@ import org.robolectric.annotation.Config
 import timur.gilfanov.messenger.annotations.Component
 import timur.gilfanov.messenger.data.source.local.database.entity.ChatEntity
 import timur.gilfanov.messenger.data.source.local.database.entity.ChatParticipantCrossRef
+import timur.gilfanov.messenger.data.source.local.database.entity.MessageEntity
+import timur.gilfanov.messenger.data.source.local.database.entity.MessageType
 import timur.gilfanov.messenger.data.source.local.database.entity.ParticipantEntity
 import timur.gilfanov.messenger.testutil.InMemoryDatabaseRule
 
@@ -32,6 +34,9 @@ class ParticipantDaoTest {
 
     private val chatDao: ChatDao
         get() = databaseRule.chatDao
+
+    private val messageDao: MessageDao
+        get() = databaseRule.messageDao
 
     @Test
     fun `insert and get participant by id`() = runTest {
@@ -288,6 +293,29 @@ class ParticipantDaoTest {
         }
 
     @Test
+    fun `deleteOrphanedParticipants preserves participant still referenced by messages`() =
+        runTest {
+            val participantId = "11111111-1111-1111-1111-111111111111"
+            val chatId = "22222222-2222-2222-2222-222222222222"
+            val messageId = "33333333-3333-3333-3333-333333333333"
+            val participant = createTestParticipant(participantId)
+            val chat = createTestChat(chatId)
+            val message = createTestMessage(messageId, chatId, participantId)
+
+            participantDao.insertParticipant(participant)
+            chatDao.insertChat(chat)
+            chatDao.insertChatParticipantCrossRef(createCrossRef(chatId, participantId))
+            messageDao.insertMessage(message)
+            chatDao.removeAllChatParticipants(chatId)
+
+            val deleted = participantDao.deleteOrphanedParticipants()
+
+            assertEquals(0, deleted)
+            assertNotNull(participantDao.getParticipantById(participantId))
+            assertNotNull(messageDao.getMessageById(messageId))
+        }
+
+    @Test
     fun `deleteOrphanedParticipants returns zero when participants table is empty`() = runTest {
         // When
         val deleted = participantDao.deleteOrphanedParticipants()
@@ -320,5 +348,17 @@ class ParticipantDaoTest {
         joinedAt = Instant.fromEpochMilliseconds(900000),
         isAdmin = false,
         isModerator = false,
+    )
+
+    private fun createTestMessage(id: String, chatId: String, senderId: String) = MessageEntity(
+        id = id,
+        chatId = chatId,
+        senderId = senderId,
+        parentId = null,
+        type = MessageType.TEXT,
+        text = "Test message",
+        imageUrl = null,
+        deliveryStatus = null,
+        createdAt = Instant.fromEpochMilliseconds(1100000),
     )
 }

--- a/app/src/test/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDaoTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDaoTest.kt
@@ -209,10 +209,116 @@ class ParticipantDaoTest {
         assertEquals(true, moderatorCrossRef.isModerator)
     }
 
+    @Test
+    fun `deleteOrphanedParticipants returns zero when all participants are referenced`() = runTest {
+        // Given - two participants, both linked to a chat
+        val participantA = createTestParticipant(UUID.randomUUID().toString(), "User A")
+        val participantB = createTestParticipant(UUID.randomUUID().toString(), "User B")
+        val chatId = UUID.randomUUID().toString()
+        val chat = createTestChat(chatId)
+        participantDao.insertParticipants(listOf(participantA, participantB))
+        chatDao.insertChat(chat)
+        chatDao.insertChatParticipantCrossRefs(
+            listOf(
+                createCrossRef(chatId, participantA.id),
+                createCrossRef(chatId, participantB.id),
+            ),
+        )
+
+        // When
+        val deleted = participantDao.deleteOrphanedParticipants()
+
+        // Then
+        assertEquals(0, deleted)
+        val remaining = participantDao.getAllParticipants()
+        assertEquals(2, remaining.size)
+    }
+
+    @Test
+    fun `deleteOrphanedParticipants removes participant whose only chat reference was deleted`() =
+        runTest {
+            // Given - participant linked to a chat, then the junction row is removed
+            val participantId = UUID.randomUUID().toString()
+            val participant = createTestParticipant(participantId)
+            val chatId = UUID.randomUUID().toString()
+            val chat = createTestChat(chatId)
+            participantDao.insertParticipant(participant)
+            chatDao.insertChat(chat)
+            chatDao.insertChatParticipantCrossRef(createCrossRef(chatId, participantId))
+            chatDao.removeAllChatParticipants(chatId)
+
+            // When
+            val deleted = participantDao.deleteOrphanedParticipants()
+
+            // Then
+            assertEquals(1, deleted)
+            assertNull(participantDao.getParticipantById(participantId))
+        }
+
+    @Test
+    fun `deleteOrphanedParticipants preserves participants still referenced by another chat`() =
+        runTest {
+            // Given - one participant in two chats, one chat is removed
+            val sharedParticipantId = UUID.randomUUID().toString()
+            val orphanParticipantId = UUID.randomUUID().toString()
+            val sharedParticipant = createTestParticipant(sharedParticipantId, "Shared")
+            val orphanParticipant = createTestParticipant(orphanParticipantId, "Orphan")
+            val chatA = createTestChat(UUID.randomUUID().toString())
+            val chatB = createTestChat(UUID.randomUUID().toString())
+            participantDao.insertParticipants(listOf(sharedParticipant, orphanParticipant))
+            chatDao.insertChat(chatA)
+            chatDao.insertChat(chatB)
+            chatDao.insertChatParticipantCrossRefs(
+                listOf(
+                    createCrossRef(chatA.id, sharedParticipantId),
+                    createCrossRef(chatB.id, sharedParticipantId),
+                    createCrossRef(chatA.id, orphanParticipantId),
+                ),
+            )
+            // Remove chatA — junction rows for chatA cascade away.
+            chatDao.deleteChat(chatA)
+
+            // When
+            val deleted = participantDao.deleteOrphanedParticipants()
+
+            // Then - shared participant stays (still in chatB), orphan is removed
+            assertEquals(1, deleted)
+            assertNotNull(participantDao.getParticipantById(sharedParticipantId))
+            assertNull(participantDao.getParticipantById(orphanParticipantId))
+        }
+
+    @Test
+    fun `deleteOrphanedParticipants returns zero when participants table is empty`() = runTest {
+        // When
+        val deleted = participantDao.deleteOrphanedParticipants()
+
+        // Then
+        assertEquals(0, deleted)
+        assertTrue(participantDao.getAllParticipants().isEmpty())
+    }
+
     private fun createTestParticipant(id: String, name: String = "Test User") = ParticipantEntity(
         id = id,
         name = name,
         pictureUrl = null,
         onlineAt = null,
+    )
+
+    private fun createTestChat(id: String) = ChatEntity(
+        id = id,
+        name = "Test Chat",
+        pictureUrl = null,
+        rules = "[]",
+        unreadMessagesCount = 0,
+        lastReadMessageId = null,
+        updatedAt = Instant.fromEpochMilliseconds(1000000),
+    )
+
+    private fun createCrossRef(chatId: String, participantId: String) = ChatParticipantCrossRef(
+        chatId = chatId,
+        participantId = participantId,
+        joinedAt = Instant.fromEpochMilliseconds(900000),
+        isAdmin = false,
+        isModerator = false,
     )
 }

--- a/docs/plans/2026-05-03-cascade-cleanup-on-chat-deletion.md
+++ b/docs/plans/2026-05-03-cascade-cleanup-on-chat-deletion.md
@@ -53,12 +53,12 @@ Files:
 - Modify: `app/src/main/java/timur/gilfanov/messenger/data/source/local/LocalSyncDataSourceImpl.kt`
 - Modify: `app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalSyncDataSourceImplTest.kt`
 
-- [ ] In `applyChatDeletedDelta` (around line 190), after the existing `chatDao.deleteChat(it)` call, invoke `participantDao.deleteOrphanedParticipants()`. The whole operation already runs inside `database.withTransaction { … }` via `applyChatDelta`, so atomicity is preserved.
-- [ ] Add tests to `LocalSyncDataSourceImplTest`:
+- [x] In `applyChatDeletedDelta` (around line 190), after the existing `chatDao.deleteChat(it)` call, invoke `participantDao.deleteOrphanedParticipants()`. The whole operation already runs inside `database.withTransaction { … }` via `applyChatDelta`, so atomicity is preserved.
+- [x] Add tests to `LocalSyncDataSourceImplTest`:
   - cascade verification: after applying `ChatDeletedDelta`, the chat's messages and `chat_participants` junction rows are gone (proves the existing FK cascade is wired and continues to work).
   - orphan cleanup: a participant who only belonged to the deleted chat is removed from the `participants` table.
   - shared participant preservation: a participant who is also a member of another chat is preserved.
-- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.data.source.local.LocalSyncDataSourceImplTest"` — must pass before Task 3.
+- [x] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.data.source.local.LocalSyncDataSourceImplTest"` — must pass before Task 3.
 
 ### Task 3: Cleanup orphaned participants in LocalChatDataSourceImpl.deleteChat
 

--- a/docs/plans/2026-05-03-cascade-cleanup-on-chat-deletion.md
+++ b/docs/plans/2026-05-03-cascade-cleanup-on-chat-deletion.md
@@ -66,13 +66,13 @@ Files:
 - Modify: `app/src/main/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImpl.kt`
 - Modify: `app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImplTest.kt`
 
-- [ ] In `deleteChat` (around line 96), after `chatDao.deleteChat(chatEntity)` and inside the existing `database.withTransaction { … }`, call `participantDao.deleteOrphanedParticipants()`. Keep the `ChatNotFound` branch unchanged.
-- [ ] Update / add tests in `LocalChatDataSourceImplTest`:
+- [x] In `deleteChat` (around line 96), after `chatDao.deleteChat(chatEntity)` and inside the existing `database.withTransaction { … }`, call `participantDao.deleteOrphanedParticipants()`. Keep the `ChatNotFound` branch unchanged.
+- [x] Update / add tests in `LocalChatDataSourceImplTest`:
   - cascade verification: after `deleteChat`, the chat's messages and junction rows are removed.
   - orphan cleanup: participants whose only chat was deleted are removed from `participants`.
   - shared participant preservation: participants who remain in another chat stay in `participants`.
   - the `ChatNotFound` test still passes and no participants are touched on that path.
-- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.data.source.local.LocalChatDataSourceImplTest"` — must pass before Task 4.
+- [x] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.data.source.local.LocalChatDataSourceImplTest"` — must pass before Task 4.
 
 ### Task 4: Verify acceptance criteria
 

--- a/docs/plans/2026-05-03-cascade-cleanup-on-chat-deletion.md
+++ b/docs/plans/2026-05-03-cascade-cleanup-on-chat-deletion.md
@@ -1,0 +1,87 @@
+# Cascade cleanup on chat deletion (issue #54)
+
+## Overview
+
+Issue #54 asks for proper cascade cleanup when a chat is deleted locally. Investigation shows Room already cascades messages (`MessageEntity.chatId → chats.id`) and junction rows (`ChatParticipantCrossRef.chatId → chats.id`) via existing `ForeignKey(onDelete = CASCADE)` declarations. The real gap is:
+
+1. Orphaned global participants in the `participants` table are never cleaned up — `Participant` has no FK back to chats, so participants linger forever once their last chat is removed.
+2. There are no tests proving the existing cascade behavior actually works (no regression coverage).
+3. Both delete paths share the gap: `LocalSyncDataSourceImpl.applyChatDeletedDelta` (server-driven delete via sync) and `LocalChatDataSourceImpl.deleteChat` (locally-initiated delete via `DeleteChatUseCase`).
+
+Per user decision, fix both paths consistently so cleanup behaves the same regardless of which path triggers the delete.
+
+## Context
+
+- Files involved:
+  - `app/src/main/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDao.kt`
+  - `app/src/main/java/timur/gilfanov/messenger/data/source/local/LocalSyncDataSourceImpl.kt`
+  - `app/src/main/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImpl.kt`
+  - `app/src/test/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDaoTest.kt`
+  - `app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalSyncDataSourceImplTest.kt`
+  - `app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImplTest.kt`
+- Related patterns:
+  - Room FK CASCADE already declared on `MessageEntity` and `ChatParticipantCrossRef` — leave those entity FK declarations alone; the orphan cleanup is a query, not a schema change, so no Room migration is needed.
+  - All multi-statement DB writes wrap in `database.withTransaction { … }` (existing pattern in both data sources).
+  - Tests use `InMemoryDatabaseRule` (Robolectric, `Room.inMemoryDatabaseBuilder` — FKs are enabled by default).
+- Dependencies: none new.
+
+## Development Approach
+
+- Testing approach: Regular (code first, then tests) — narrow well-bounded change with existing test infrastructure.
+- Complete each task fully before moving to the next.
+- Cleanup must run inside the same transaction as the chat delete so the operation is atomic.
+- CRITICAL: every task MUST include new/updated tests.
+- CRITICAL: all tests must pass before starting the next task.
+
+## Implementation Steps
+
+### Task 1: Add orphan-cleanup query to ParticipantDao
+
+Add a single query that deletes participants no longer referenced by any row in `chat_participants`. This is the building block both delete paths will reuse.
+
+Files:
+- Modify: `app/src/main/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDao.kt`
+- Modify: `app/src/test/java/timur/gilfanov/messenger/data/source/local/database/dao/ParticipantDaoTest.kt`
+
+- [x] Add `@Query("DELETE FROM participants WHERE id NOT IN (SELECT participantId FROM chat_participants)") suspend fun deleteOrphanedParticipants(): Int` to `ParticipantDao`. Returning the deleted-row count keeps the query observable in tests and aids future logging/metrics.
+- [x] Add tests in `ParticipantDaoTest` covering: (a) returns 0 and deletes nothing when every participant is still referenced, (b) deletes only the participants whose only chat reference was removed, (c) leaves participants who remain referenced by at least one other chat, (d) returns 0 when the participants table is empty.
+- [x] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.data.source.local.database.dao.ParticipantDaoTest"` — must pass before Task 2.
+
+### Task 2: Cleanup orphaned participants in applyChatDeletedDelta
+
+Files:
+- Modify: `app/src/main/java/timur/gilfanov/messenger/data/source/local/LocalSyncDataSourceImpl.kt`
+- Modify: `app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalSyncDataSourceImplTest.kt`
+
+- [ ] In `applyChatDeletedDelta` (around line 190), after the existing `chatDao.deleteChat(it)` call, invoke `participantDao.deleteOrphanedParticipants()`. The whole operation already runs inside `database.withTransaction { … }` via `applyChatDelta`, so atomicity is preserved.
+- [ ] Add tests to `LocalSyncDataSourceImplTest`:
+  - cascade verification: after applying `ChatDeletedDelta`, the chat's messages and `chat_participants` junction rows are gone (proves the existing FK cascade is wired and continues to work).
+  - orphan cleanup: a participant who only belonged to the deleted chat is removed from the `participants` table.
+  - shared participant preservation: a participant who is also a member of another chat is preserved.
+- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.data.source.local.LocalSyncDataSourceImplTest"` — must pass before Task 3.
+
+### Task 3: Cleanup orphaned participants in LocalChatDataSourceImpl.deleteChat
+
+Files:
+- Modify: `app/src/main/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImpl.kt`
+- Modify: `app/src/test/java/timur/gilfanov/messenger/data/source/local/LocalChatDataSourceImplTest.kt`
+
+- [ ] In `deleteChat` (around line 96), after `chatDao.deleteChat(chatEntity)` and inside the existing `database.withTransaction { … }`, call `participantDao.deleteOrphanedParticipants()`. Keep the `ChatNotFound` branch unchanged.
+- [ ] Update / add tests in `LocalChatDataSourceImplTest`:
+  - cascade verification: after `deleteChat`, the chat's messages and junction rows are removed.
+  - orphan cleanup: participants whose only chat was deleted are removed from `participants`.
+  - shared participant preservation: participants who remain in another chat stay in `participants`.
+  - the `ChatNotFound` test still passes and no participants are touched on that path.
+- [ ] Run `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.data.source.local.LocalChatDataSourceImplTest"` — must pass before Task 4.
+
+### Task 4: Verify acceptance criteria
+
+- [ ] Run `./gradlew ktlintFormat detekt --auto-correct`.
+- [ ] Run `./gradlew :app:testMockDebugUnitTest` for the full app unit-test suite to catch any unexpected regression in repository or sync tests that exercise delete flows.
+- [ ] Run `./gradlew :app:compileMockDebugAndroidTestKotlin` (signature change on `ParticipantDao` adds a new method — all `:app` androidTest sources compile against it).
+- [ ] Verify test coverage for the touched files meets the 80% target (`./gradlew :app:koverHtmlReportMockDebug` or the project's standard coverage task).
+
+### Task 5: Update documentation
+
+- [ ] No README/CLAUDE.md changes expected (internal data-source behavior, no new pattern). Confirm no doc updates are required and skip if so.
+- [ ] Move this plan to `docs/plans/completed/`.

--- a/docs/plans/completed/2026-05-03-cascade-cleanup-on-chat-deletion.md
+++ b/docs/plans/completed/2026-05-03-cascade-cleanup-on-chat-deletion.md
@@ -76,12 +76,12 @@ Files:
 
 ### Task 4: Verify acceptance criteria
 
-- [ ] Run `./gradlew ktlintFormat detekt --auto-correct`.
-- [ ] Run `./gradlew :app:testMockDebugUnitTest` for the full app unit-test suite to catch any unexpected regression in repository or sync tests that exercise delete flows.
-- [ ] Run `./gradlew :app:compileMockDebugAndroidTestKotlin` (signature change on `ParticipantDao` adds a new method — all `:app` androidTest sources compile against it).
-- [ ] Verify test coverage for the touched files meets the 80% target (`./gradlew :app:koverHtmlReportMockDebug` or the project's standard coverage task).
+- [x] Run `./gradlew ktlintFormat detekt --auto-correct`.
+- [x] Run `./gradlew :app:testMockDebugUnitTest` for the full app unit-test suite to catch any unexpected regression in repository or sync tests that exercise delete flows.
+- [x] Run `./gradlew :app:compileMockDebugAndroidTestKotlin` (signature change on `ParticipantDao` adds a new method — all `:app` androidTest sources compile against it).
+- [x] Verify test coverage for the touched files meets the 80% target (`./gradlew :app:koverHtmlReportMockDebug` or the project's standard coverage task).
 
 ### Task 5: Update documentation
 
-- [ ] No README/CLAUDE.md changes expected (internal data-source behavior, no new pattern). Confirm no doc updates are required and skip if so.
-- [ ] Move this plan to `docs/plans/completed/`.
+- [x] No README/CLAUDE.md changes expected (internal data-source behavior, no new pattern). Confirm no doc updates are required and skip if so.
+- [x] Move this plan to `docs/plans/completed/`.


### PR DESCRIPTION
Closes #54

## Summary
Implements cascade cleanup for deleted chats so local storage does not retain chat-scoped rows or participants that are no longer referenced.

Participant cleanup is conservative: a participant is deleted only when no chat or message still references it. This keeps deleted-chat cleanup from removing participants that remain valid through another chat or retained message history.

## Changes
- Added DAO support for deleting participants that no longer have chat or message references.
- Runs orphan participant cleanup after local chat deletion paths finish removing chat-specific data.
- Expanded DAO and local data source tests for referenced, orphaned, and message-retained participants.
- Replaced non-deterministic test UUID generation with fixed IDs for reproducibility.

## Testing
Validation covered formatting, static analysis, and focused local database unit tests.
- [x] Unit tests added or updated
- [ ] Manually tested
- [x] Edge cases considered

## Screenshots / Demo
Not applicable. This PR does not affect UI.

## Acceptance criteria
- [x] Messages associated with a deleted chat are removed.
- [x] Chat-participant relationships for a deleted chat are removed.
- [x] Participants that are no longer referenced are cleaned up.
- [x] Participants still referenced by another chat or by messages are preserved.
- [x] Foreign key constraints remain respected.

## Breaking Changes
None.

## Follow-ups
None.
