### PR TITLE
Validate chat message input before send

### DIFF
--- a/app/src/main/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModel.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModel.kt
@@ -112,30 +112,44 @@ class ChatViewModel @AssistedInject constructor(
         if (value !is ChatUiState.Ready) return
         if (value.isSending) return
 
-        _state.update { (it as? ChatUiState.Ready)?.copy(isSending = true) ?: it }
-        viewModelScope.launch {
-            val request = SendRequest(messageId, now, currentInputText)
-            val message = textMessage(request.messageId, request.now, request.text)
-            sendMessageUseCase(currentChat!!, message).collect { result ->
-                when (result) {
-                    is ResultWithError.Success -> {
-                        if (result.data is TextMessage &&
-                            currentInputText == request.text
-                        ) {
-                            currentInputText = ""
-                            _effects.send(ChatSideEffect.ClearInputText)
+        val inputTextValidationError = validateInputText(currentInputText)
+        if (inputTextValidationError != null) {
+            _state.update {
+                (it as? ChatUiState.Ready)?.copy(
+                    inputTextValidationError = inputTextValidationError,
+                ) ?: it
+            }
+        } else {
+            _state.update {
+                (it as? ChatUiState.Ready)?.copy(
+                    inputTextValidationError = null,
+                    isSending = true,
+                ) ?: it
+            }
+            viewModelScope.launch {
+                val request = SendRequest(messageId, now, currentInputText)
+                val message = textMessage(request.messageId, request.now, request.text)
+                sendMessageUseCase(currentChat!!, message).collect { result ->
+                    when (result) {
+                        is ResultWithError.Success -> {
+                            if (result.data is TextMessage &&
+                                currentInputText == request.text
+                            ) {
+                                currentInputText = ""
+                                _effects.send(ChatSideEffect.ClearInputText)
+                            }
+                            _state.update {
+                                (it as? Ready)?.copy(isSending = false) ?: it
+                            }
                         }
-                        _state.update {
-                            (it as? Ready)?.copy(isSending = false) ?: it
-                        }
-                    }
 
-                    is ResultWithError.Failure -> {
-                        _state.update {
-                            (it as? Ready)?.copy(
-                                isSending = false,
-                                dialogError = SendMessageError(result.error),
-                            ) ?: it
+                        is ResultWithError.Failure -> {
+                            _state.update {
+                                (it as? Ready)?.copy(
+                                    isSending = false,
+                                    dialogError = SendMessageError(result.error),
+                                ) ?: it
+                            }
                         }
                     }
                 }

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelMessageSendingTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelMessageSendingTest.kt
@@ -3,28 +3,34 @@ package timur.gilfanov.messenger.ui.screen.chat
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import java.util.UUID
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Instant
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import timur.gilfanov.messenger.annotations.Component
+import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.message.DeliveryError
 import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus
 import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Sending
 import timur.gilfanov.messenger.domain.entity.message.MessageId
+import timur.gilfanov.messenger.domain.entity.message.TextMessage
 import timur.gilfanov.messenger.domain.entity.message.buildTextMessage
 import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidatorImpl
 import timur.gilfanov.messenger.domain.entity.message.validation.TextValidationError
 import timur.gilfanov.messenger.domain.usecase.chat.MarkMessagesAsReadUseCase
 import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
+import timur.gilfanov.messenger.domain.usecase.common.LocalStorageError
 import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageError
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
+import timur.gilfanov.messenger.domain.usecase.message.repository.SendMessageRepositoryError
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFakeWithStatusFlow
@@ -44,6 +50,56 @@ class ChatViewModelMessageSendingTest {
         private val TEST_MESSAGE_ID_1 =
             MessageId(UUID.fromString("00000000-0000-0000-0000-000000000004"))
         private val TEST_INSTANT = Instant.fromEpochMilliseconds(1000)
+    }
+
+    @Test
+    fun `invalid message text is rejected locally without sending`() = runTest {
+        listOf(
+            "" to TextValidationError.Empty,
+            "   \n\t" to TextValidationError.Empty,
+            "a".repeat(TextMessage.MAX_TEXT_LENGTH + 1) to
+                TextValidationError.TooLong(TextMessage.MAX_TEXT_LENGTH),
+        ).forEach { (inputText, expectedError) ->
+            val chat = createTestChat(TEST_CHAT_ID, TEST_CURRENT_USER_ID, TEST_OTHER_USER_ID)
+            val repository = MessengerRepositoryFake(chat = chat)
+            val viewModel = createViewModel(repository)
+
+            viewModel.effects.test {
+                viewModel.state.test {
+                    var readyState = awaitItem()
+                    while (readyState !is ChatUiState.Ready) {
+                        readyState = awaitItem()
+                    }
+                    assertFalse(readyState.isSending)
+
+                    if (inputText.isNotEmpty()) {
+                        viewModel.onInputTextChanged(inputText)
+
+                        val validationErrorState = awaitItem()
+                        assertTrue(validationErrorState is ChatUiState.Ready)
+                        assertEquals(
+                            expectedError,
+                            validationErrorState.inputTextValidationError,
+                        )
+                    }
+
+                    viewModel.sendMessage(TEST_MESSAGE_ID_1, TEST_INSTANT)
+
+                    val currentState = if (inputText.isEmpty()) {
+                        awaitItem()
+                    } else {
+                        viewModel.state.value
+                    }
+                    assertTrue(currentState is ChatUiState.Ready)
+                    assertFalse(currentState.isSending)
+                    assertEquals(expectedError, currentState.inputTextValidationError)
+                    assertTrue(repository.sentMessages.isEmpty())
+                    expectNoEvents()
+                }
+
+                expectNoEvents()
+            }
+        }
     }
 
     @Test
@@ -105,6 +161,8 @@ class ChatViewModelMessageSendingTest {
                     }
                 }
 
+                val sentMessage = assertIs<TextMessage>(rep.sentMessages.single())
+                assertEquals("Test message", sentMessage.text)
                 assertIs<ChatSideEffect.ClearInputText>(awaitItem())
                 expectNoEvents()
             }
@@ -118,7 +176,14 @@ class ChatViewModelMessageSendingTest {
         val otherUserId = TEST_OTHER_USER_ID
 
         val chat = createTestChat(chatId, currentUserId, otherUserId)
-        val repository = MessengerRepositoryFake(chat = chat)
+        val repository = MessengerRepositoryFake(
+            chat = chat,
+            flowSendMessageResult = flowOf(
+                ResultWithError.Failure(
+                    SendMessageRepositoryError.LocalOperationFailed(LocalStorageError.Corrupted),
+                ),
+            ),
+        )
 
         val sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl())
         val receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository)
@@ -141,13 +206,7 @@ class ChatViewModelMessageSendingTest {
             }
             assertNull(readyState.dialogError)
 
-            viewModel.onInputTextChanged("")
-
-            val validationErrorState = awaitItem()
-            assertTrue(validationErrorState is ChatUiState.Ready)
-            assertIs<TextValidationError.Empty>(validationErrorState.inputTextValidationError)
-
-            // Sending an empty text message should cause an error
+            viewModel.onInputTextChanged("Test message")
             viewModel.sendMessage(TEST_MESSAGE_ID_1, TEST_INSTANT)
 
             val sendingState = awaitItem()
@@ -158,7 +217,7 @@ class ChatViewModelMessageSendingTest {
             assertTrue(errorState is ChatUiState.Ready)
             assertFalse(errorState.isSending)
             assertIs<ReadyError.SendMessageError>(errorState.dialogError)
-            assertIs<SendMessageError.MessageIsNotValid>(
+            assertIs<SendMessageError.LocalOperationFailed>(
                 (errorState.dialogError as ReadyError.SendMessageError).error,
             )
 
@@ -169,4 +228,13 @@ class ChatViewModelMessageSendingTest {
             assertNull(clearedState.dialogError)
         }
     }
+
+    private fun createViewModel(repository: MessengerRepositoryFake): ChatViewModel = ChatViewModel(
+        chatIdUuid = TEST_CHAT_ID.id,
+        savedStateHandle = SavedStateHandle(),
+        sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl()),
+        receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository),
+        getPagedMessagesUseCase = GetPagedMessagesUseCase(repository),
+        markMessagesAsReadUseCase = MarkMessagesAsReadUseCase(repository),
+    )
 }

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
@@ -92,24 +92,32 @@ object ChatViewModelTestFixtures {
         private val flowChat: Flow<
             ResultWithError<Chat, ReceiveChatUpdatesRepositoryError>,
             >? = null,
+        private val flowSendMessageResult: Flow<
+            ResultWithError<Message, SendMessageRepositoryError>,
+            >? = null,
         private val flowSendMessage: Flow<Message>? = null,
         private val pagedMessages: List<Message>? = null,
     ) : ChatRepository,
         MessageRepository {
 
+        val sentMessages = mutableListOf<Message>()
+
         override suspend fun sendMessage(
             message: Message,
-        ): Flow<ResultWithError<Message, SendMessageRepositoryError>> = flowSendMessage?.map {
-            ResultWithError.Success<Message, SendMessageRepositoryError>(it)
+        ): Flow<ResultWithError<Message, SendMessageRepositoryError>> {
+            sentMessages += message
+            return flowSendMessageResult ?: flowSendMessage?.map {
+                ResultWithError.Success<Message, SendMessageRepositoryError>(it)
+            }
+                ?: flowOf(
+                    ResultWithError.Success<Message, SendMessageRepositoryError>(
+                        when (message) {
+                            is TextMessage -> message.copy(deliveryStatus = Sending(0))
+                            else -> message
+                        },
+                    ),
+                )
         }
-            ?: flowOf(
-                ResultWithError.Success<Message, SendMessageRepositoryError>(
-                    when (message) {
-                        is TextMessage -> message.copy(deliveryStatus = Sending(0))
-                        else -> message
-                    },
-                ),
-            )
 
         override suspend fun receiveChatUpdates(
             chatId: ChatId,
@@ -145,31 +153,35 @@ object ChatViewModelTestFixtures {
         MessageRepository {
 
         private val chatFlow = MutableStateFlow(chat)
+        val sentMessages = mutableListOf<Message>()
 
         @OptIn(ExperimentalCoroutinesApi::class)
         override suspend fun sendMessage(
             message: Message,
-        ): Flow<ResultWithError<Message, SendMessageRepositoryError>> = flowOf(
-            *(
-                statuses.map {
-                    Success<Message, SendMessageRepositoryError>(
-                        (message as TextMessage).copy(deliveryStatus = it),
-                    )
-                }.toTypedArray()
-                ),
-        ).onEach { result ->
-            val msg = result.data
-            delay(10) // to pass immediate state updates, like text input
-            chatFlow.update { currentChat ->
-                val messages = currentChat.messages.toMutableList().apply {
-                    val indexOfFirst = indexOfFirst { it.id == msg.id }
-                    if (indexOfFirst != -1) {
-                        this[indexOfFirst] = msg
-                    } else {
-                        add(msg)
-                    }
-                }.toPersistentList()
-                currentChat.copy(messages = messages)
+        ): Flow<ResultWithError<Message, SendMessageRepositoryError>> {
+            sentMessages += message
+            return flowOf(
+                *(
+                    statuses.map {
+                        Success<Message, SendMessageRepositoryError>(
+                            (message as TextMessage).copy(deliveryStatus = it),
+                        )
+                    }.toTypedArray()
+                    ),
+            ).onEach { result ->
+                val msg = result.data
+                delay(10) // to pass immediate state updates, like text input
+                chatFlow.update { currentChat ->
+                    val messages = currentChat.messages.toMutableList().apply {
+                        val indexOfFirst = indexOfFirst { it.id == msg.id }
+                        if (indexOfFirst != -1) {
+                            this[indexOfFirst] = msg
+                        } else {
+                            add(msg)
+                        }
+                    }.toPersistentList()
+                    currentChat.copy(messages = messages)
+                }
             }
         }
 


### PR DESCRIPTION
Closes #378

## Summary
Validate outgoing chat message text locally in `ChatViewModel` before creating a `TextMessage` or invoking `SendMessageUseCase`.

The validation stays in `ChatViewModel` and reuses the existing `TextValidator(TextMessage.MAX_TEXT_LENGTH)` contract. No new validator, side effect, UI state field, or DI/API contract was added.

## Changes
- Reject blank and whitespace-only input with `TextValidationError.Empty` before entering the send flow.
- Reject input longer than `TextMessage.MAX_TEXT_LENGTH` with `TextValidationError.TooLong` before entering the send flow.
- Preserve valid send behavior, including one-time `ClearInputText` emission after successful sends.
- Extend chat ViewModel test fixtures to record sent messages and support repository failure results.

## Testing
- [x] Unit tests added or updated
- [ ] Manually tested
- [x] Edge cases considered

## Screenshots / Demo
Not applicable; behavior is covered at the ViewModel layer and no UI layout changed.

## Acceptance criteria
- [x] Blank messages are rejected locally with no send use case call.
- [x] Whitespace-only messages are rejected locally with no send use case call.
- [x] Messages longer than 2000 characters are rejected locally with no send use case call.
- [x] Valid messages still submit normally.
- [x] Tests cover validation and no-call behavior.

## Breaking Changes
None.

## Follow-ups
- [ ] None.