### PR TITLE
Retry failed outgoing chat messages

### DIFF
--- a/app/src/main/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModel.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModel.kt
@@ -110,6 +110,8 @@ class ChatViewModel @AssistedInject constructor(
 
     private var currentChat: Chat? = null
 
+    private val retryingMessageIds = mutableSetOf<MessageId>()
+
     fun sendMessage(
         messageId: MessageId = MessageId(UUID.randomUUID()),
         now: Instant = Clock.System.now(),
@@ -206,8 +208,10 @@ class ChatViewModel @AssistedInject constructor(
      * Re-sends a previously failed outgoing message, reusing its id and text.
      *
      * No-op when the chat is not [ChatUiState.Ready], when [messageId] is absent from the
-     * current timeline, or when its delivery status is not [DeliveryStatus.Failed]. Only the
-     * delivery status is reset (to `null`) so the send use case accepts the message; the
+     * current timeline, when its delivery status is not [DeliveryStatus.Failed], or when a
+     * retry for the same [messageId] is already in flight (so a double-invoke cannot launch
+     * concurrent sends for one message; distinct messages may still retry concurrently). Only
+     * the delivery status is reset (to `null`) so the send use case accepts the message; the
      * Sending/Sent/Failed transition is reflected through the message timeline rather than
      * the composer state, so this neither toggles the sending indicator nor clears the input.
      * A repeated failure follows the same dialog policy as [sendMessage] and keeps the
@@ -218,16 +222,20 @@ class ChatViewModel @AssistedInject constructor(
         val failed = chat.messages
             .filterIsInstance<TextMessage>()
             .firstOrNull { it.id == messageId && it.deliveryStatus is DeliveryStatus.Failed }
-            ?: return
+        if (failed == null || !retryingMessageIds.add(messageId)) return
 
         val retry = failed.copy(deliveryStatus = null)
         viewModelScope.launch {
-            sendMessageUseCase(chat, retry, now).collect { result ->
-                when (result) {
-                    is ResultWithError.Success -> Unit
-                    is ResultWithError.Failure ->
-                        handleSendFailure(result.error, SendProgress(acceptedLocally = true))
+            try {
+                sendMessageUseCase(chat, retry, now).collect { result ->
+                    when (result) {
+                        is ResultWithError.Success -> Unit
+                        is ResultWithError.Failure ->
+                            handleSendFailure(result.error, SendProgress(acceptedLocally = true))
+                    }
                 }
+            } finally {
+                retryingMessageIds.remove(messageId)
             }
         }
     }

--- a/app/src/main/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModel.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModel.kt
@@ -134,7 +134,14 @@ class ChatViewModel @AssistedInject constructor(
                 ) ?: it
             }
             viewModelScope.launch {
-                val message = textMessage(request.messageId, request.now, request.text)
+                val message = TextMessage(
+                    id = request.messageId,
+                    parentId = null,
+                    sender = currentChat!!.participants.first { it.isCurrentUser },
+                    recipient = chatId,
+                    createdAt = request.now,
+                    text = request.text,
+                )
                 val progress = SendProgress()
                 sendMessageUseCase(currentChat!!, message, request.now).collect { result ->
                     when (result) {
@@ -195,15 +202,35 @@ class ChatViewModel @AssistedInject constructor(
         }
     }
 
-    private fun textMessage(messageId: MessageId, now: Instant, text: String): TextMessage =
-        TextMessage(
-            id = messageId,
-            parentId = null,
-            sender = currentChat!!.participants.first { it.isCurrentUser },
-            recipient = chatId,
-            createdAt = now,
-            text = text,
-        )
+    /**
+     * Re-sends a previously failed outgoing message, reusing its id and text.
+     *
+     * No-op when the chat is not [ChatUiState.Ready], when [messageId] is absent from the
+     * current timeline, or when its delivery status is not [DeliveryStatus.Failed]. Only the
+     * delivery status is reset (to `null`) so the send use case accepts the message; the
+     * Sending/Sent/Failed transition is reflected through the message timeline rather than
+     * the composer state, so this neither toggles the sending indicator nor clears the input.
+     * A repeated failure follows the same dialog policy as [sendMessage] and keeps the
+     * message failed and retryable.
+     */
+    fun retryMessage(messageId: MessageId, now: Instant = Clock.System.now()) {
+        val chat = currentChat.takeIf { _state.value is ChatUiState.Ready } ?: return
+        val failed = chat.messages
+            .filterIsInstance<TextMessage>()
+            .firstOrNull { it.id == messageId && it.deliveryStatus is DeliveryStatus.Failed }
+            ?: return
+
+        val retry = failed.copy(deliveryStatus = null)
+        viewModelScope.launch {
+            sendMessageUseCase(chat, retry, now).collect { result ->
+                when (result) {
+                    is ResultWithError.Success -> Unit
+                    is ResultWithError.Failure ->
+                        handleSendFailure(result.error, SendProgress(acceptedLocally = true))
+                }
+            }
+        }
+    }
 
     fun dismissDialogError() {
         _state.update { if (it is ChatUiState.Ready) it.copy(dialogError = null) else it }

--- a/app/src/main/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModel.kt
+++ b/app/src/main/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -208,20 +209,32 @@ class ChatViewModel @AssistedInject constructor(
      * Re-sends a previously failed outgoing message, reusing its id and text.
      *
      * No-op when the chat is not [ChatUiState.Ready], when [messageId] is absent from the
-     * current timeline, when its delivery status is not [DeliveryStatus.Failed], or when a
-     * retry for the same [messageId] is already in flight (so a double-invoke cannot launch
-     * concurrent sends for one message; distinct messages may still retry concurrently). Only
-     * the delivery status is reset (to `null`) so the send use case accepts the message; the
-     * Sending/Sent/Failed transition is reflected through the message timeline rather than
+     * current timeline, when its delivery status is not [DeliveryStatus.Failed], when the
+     * message was not sent by the current user, or when a retry for the same [messageId] is
+     * already in flight (so a double-invoke cannot launch concurrent sends for one message;
+     * distinct messages may still retry concurrently). The current-user check mirrors the
+     * sender that [sendMessage] stamps on a new message and guards against re-sending a
+     * foreign message — e.g. a corrupted synced entry that deserialized to
+     * [DeliveryStatus.Failed] — as the authenticated user.
+     *
+     * Only the delivery status is reset (to `null`) so the send use case accepts the message;
+     * the Sending/Sent/Failed transition is reflected through the message timeline rather than
      * the composer state, so this neither toggles the sending indicator nor clears the input.
-     * A repeated failure follows the same dialog policy as [sendMessage] and keeps the
-     * message failed and retryable.
+     * A repeated failure follows the same dialog policy as [sendMessage]; whether the message
+     * stays retryable is governed by its timeline delivery status, which the send path
+     * persists as [DeliveryStatus.Failed] on a normal failure. The ViewModel never mutates
+     * the timeline itself on failure.
      */
     fun retryMessage(messageId: MessageId, now: Instant = Clock.System.now()) {
         val chat = currentChat.takeIf { _state.value is ChatUiState.Ready } ?: return
+        val currentUserId = chat.participants.first { it.isCurrentUser }.id
         val failed = chat.messages
             .filterIsInstance<TextMessage>()
-            .firstOrNull { it.id == messageId && it.deliveryStatus is DeliveryStatus.Failed }
+            .firstOrNull {
+                it.id == messageId &&
+                    it.deliveryStatus is DeliveryStatus.Failed &&
+                    it.sender.id == currentUserId
+            }
         if (failed == null || !retryingMessageIds.add(messageId)) return
 
         val retry = failed.copy(deliveryStatus = null)
@@ -256,14 +269,16 @@ class ChatViewModel @AssistedInject constructor(
     private suspend fun observeChatUpdates() {
         receiveChatUpdatesUseCase(chatId)
             .distinctUntilChanged()
+            .onEach { result ->
+                if (result is ResultWithError.Success) {
+                    currentChat = result.data
+                }
+            }
             .debounce(STATE_UPDATE_DEBOUNCE)
             .collect { result ->
                 when (result) {
-                    is ResultWithError.Success -> {
-                        val chat = result.data
-                        currentChat = chat
-                        _state.value = updateUiStateFromChat(_state.value, chat)
-                    }
+                    is ResultWithError.Success ->
+                        _state.value = updateUiStateFromChat(_state.value, result.data)
 
                     is ResultWithError.Failure -> when (result.error) {
                         ReceiveChatUpdatesRepositoryError.ChatNotFound ->

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelRetryTest.kt
@@ -6,11 +6,16 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -20,6 +25,7 @@ import org.junit.experimental.categories.Category
 import timur.gilfanov.messenger.annotations.Component
 import timur.gilfanov.messenger.domain.entity.ResultWithError
 import timur.gilfanov.messenger.domain.entity.chat.Chat
+import timur.gilfanov.messenger.domain.entity.chat.CreateMessageRule
 import timur.gilfanov.messenger.domain.entity.chat.Participant
 import timur.gilfanov.messenger.domain.entity.message.DeliveryError
 import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus
@@ -29,15 +35,18 @@ import timur.gilfanov.messenger.domain.entity.message.MessageId
 import timur.gilfanov.messenger.domain.entity.message.TextMessage
 import timur.gilfanov.messenger.domain.entity.message.buildTextMessage
 import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidatorImpl
+import timur.gilfanov.messenger.domain.usecase.chat.ChatRepository
 import timur.gilfanov.messenger.domain.usecase.chat.MarkMessagesAsReadUseCase
 import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
 import timur.gilfanov.messenger.domain.usecase.common.LocalStorageError
 import timur.gilfanov.messenger.domain.usecase.common.RemoteError
 import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
+import timur.gilfanov.messenger.domain.usecase.message.MessageRepository
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageError
 import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
 import timur.gilfanov.messenger.domain.usecase.message.repository.SendMessageRepositoryError
 import timur.gilfanov.messenger.testutil.MainDispatcherRule
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFake
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFakeWithTimeline
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CHAT_ID
 import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CURRENT_USER_ID
@@ -74,28 +83,49 @@ class ChatViewModelRetryTest {
         return baseChat.copy(messages = persistentListOf(message)) to currentUser
     }
 
-    private fun progress(sender: Participant, status: DeliveryStatus): TextMessage =
-        buildTextMessage {
-            id = FAILED_MESSAGE_ID
-            this.sender = sender
-            recipient = TEST_CHAT_ID
-            createdAt = TEST_INSTANT
-            text = TEXT
-            deliveryStatus = status
-        }
+    private fun progress(
+        sender: Participant,
+        status: DeliveryStatus,
+        id: MessageId = FAILED_MESSAGE_ID,
+    ): TextMessage = buildTextMessage {
+        this.id = id
+        this.sender = sender
+        recipient = TEST_CHAT_ID
+        createdAt = TEST_INSTANT
+        text = TEXT
+        deliveryStatus = status
+    }
 
-    private fun createViewModel(repository: MessengerRepositoryFakeWithTimeline): ChatViewModel =
-        ChatViewModel(
-            chatIdUuid = TEST_CHAT_ID.id,
-            savedStateHandle = SavedStateHandle(),
-            sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl()),
-            receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository),
-            getPagedMessagesUseCase = GetPagedMessagesUseCase(repository),
-            markMessagesAsReadUseCase = MarkMessagesAsReadUseCase(repository),
-        )
+    private fun <R> createViewModel(
+        repository: R,
+    ): ChatViewModel
+        where R : ChatRepository, R : MessageRepository = ChatViewModel(
+        chatIdUuid = TEST_CHAT_ID.id,
+        savedStateHandle = SavedStateHandle(),
+        sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl()),
+        receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository),
+        getPagedMessagesUseCase = GetPagedMessagesUseCase(repository),
+        markMessagesAsReadUseCase = MarkMessagesAsReadUseCase(repository),
+    )
+
+    private fun MessengerRepositoryFakeWithTimeline.timelineMessage(): TextMessage =
+        assertIs<TextMessage>(timeline.single())
+
+    /**
+     * Asserts on the message actually handed to the send use case (captured by the fake),
+     * not the scripted timeline echo — so an id-reuse regression cannot hide behind the
+     * hardcoded [progress] id.
+     */
+    private fun MessengerRepositoryFakeWithTimeline.assertRetriedMessageIsFailedOne() {
+        val sent = assertIs<TextMessage>(sentMessages.first())
+        assertEquals(FAILED_MESSAGE_ID, sent.id)
+        assertEquals(TEXT, sent.text)
+        assertNull(sent.deliveryStatus)
+        assertEquals(TEST_INSTANT, sent.createdAt)
+    }
 
     @Test
-    fun `retry re-sends same id and text with cleared status and no dialog`() = runTest {
+    fun `retry re-sends same id and text, clears status, and reaches Sent`() = runTest {
         val (chat, currentUser) = chatWith(DeliveryStatus.Failed(DeliveryError.NetworkUnavailable))
         val retryFlow: Flow<ResultWithError<Message, SendMessageRepositoryError>> = flowOf(
             ResultWithError.Success(progress(currentUser, Sending(0))),
@@ -109,7 +139,8 @@ class ChatViewModelRetryTest {
         backgroundScope.launch { viewModel.effects.collect { effects += it } }
         advanceUntilIdle()
 
-        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        val laterNow = TEST_INSTANT + 10.seconds
+        viewModel.retryMessage(FAILED_MESSAGE_ID, laterNow)
         advanceUntilIdle()
 
         assertEquals(1, repository.sentMessages.size)
@@ -117,15 +148,18 @@ class ChatViewModelRetryTest {
         assertEquals(FAILED_MESSAGE_ID, retried.id)
         assertEquals(TEXT, retried.text)
         assertNull(retried.deliveryStatus)
+        assertEquals(TEST_INSTANT, retried.createdAt)
 
         val state = viewModel.state.value
         assertTrue(state is ChatUiState.Ready)
         assertNull(state.dialogError)
+        assertEquals(false, state.isSending)
         assertTrue(effects.isEmpty())
+        assertEquals(DeliveryStatus.Sent, repository.timelineMessage().deliveryStatus)
     }
 
     @Test
-    fun `retry local failure shows dialog and message stays retryable`() = runTest {
+    fun `retry local failure shows dialog and message stays failed and retryable`() = runTest {
         val (chat, currentUser) = chatWith(DeliveryStatus.Failed(DeliveryError.NetworkUnavailable))
         val failingRetry: Flow<ResultWithError<Message, SendMessageRepositoryError>> = flowOf(
             ResultWithError.Success(progress(currentUser, Sending(0))),
@@ -145,10 +179,12 @@ class ChatViewModelRetryTest {
         advanceUntilIdle()
 
         assertEquals(1, repository.sentMessages.size)
+        repository.assertRetriedMessageIsFailedOne()
         val afterFailure = viewModel.state.value
         assertTrue(afterFailure is ChatUiState.Ready)
         val dialogError = assertIs<ReadyError.SendMessageError>(afterFailure.dialogError)
         assertIs<SendMessageError.LocalOperationFailed>(dialogError.error)
+        assertIs<DeliveryStatus.Failed>(repository.timelineMessage().deliveryStatus)
 
         viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
         advanceUntilIdle()
@@ -156,7 +192,7 @@ class ChatViewModelRetryTest {
     }
 
     @Test
-    fun `retry remote failure stays silent and message stays retryable`() = runTest {
+    fun `retry remote failure stays silent and message stays failed and retryable`() = runTest {
         val (chat, currentUser) = chatWith(DeliveryStatus.Failed(DeliveryError.NetworkUnavailable))
         val failingRetry: Flow<ResultWithError<Message, SendMessageRepositoryError>> = flowOf(
             ResultWithError.Success(progress(currentUser, Sending(0))),
@@ -176,13 +212,124 @@ class ChatViewModelRetryTest {
         advanceUntilIdle()
 
         assertEquals(1, repository.sentMessages.size)
+        repository.assertRetriedMessageIsFailedOne()
         val afterFailure = viewModel.state.value
         assertTrue(afterFailure is ChatUiState.Ready)
         assertNull(afterFailure.dialogError)
+        assertIs<DeliveryStatus.Failed>(repository.timelineMessage().deliveryStatus)
 
         viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
         advanceUntilIdle()
         assertEquals(2, repository.sentMessages.size)
+    }
+
+    @Test
+    fun `retry succeeds under debounce rule despite its own failed timeline entry`() = runTest {
+        val (baseChat, currentUser) =
+            chatWith(DeliveryStatus.Failed(DeliveryError.NetworkUnavailable))
+        val chat = baseChat.copy(
+            rules = persistentSetOf(CreateMessageRule.Debounce(5.seconds)),
+        )
+        val retryFlow: Flow<ResultWithError<Message, SendMessageRepositoryError>> = flowOf(
+            ResultWithError.Success(progress(currentUser, Sending(0))),
+            ResultWithError.Success(progress(currentUser, DeliveryStatus.Sent)),
+        )
+        val repository = MessengerRepositoryFakeWithTimeline(chat, listOf(retryFlow))
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        val withinDebounceWindow = TEST_INSTANT + 1.seconds
+        viewModel.retryMessage(FAILED_MESSAGE_ID, withinDebounceWindow)
+        advanceUntilIdle()
+
+        assertEquals(1, repository.sentMessages.size)
+        repository.assertRetriedMessageIsFailedOne()
+        val state = viewModel.state.value
+        assertTrue(state is ChatUiState.Ready)
+        assertNull(state.dialogError)
+        assertEquals(DeliveryStatus.Sent, repository.timelineMessage().deliveryStatus)
+    }
+
+    @Test
+    fun `concurrent retry of the same message launches only one send`() = runTest {
+        val (chat, currentUser) = chatWith(DeliveryStatus.Failed(DeliveryError.NetworkUnavailable))
+        val gate = Channel<ResultWithError<Message, SendMessageRepositoryError>>(Channel.UNLIMITED)
+        val repository = MessengerRepositoryFakeWithTimeline(chat, listOf(gate.receiveAsFlow()))
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+
+        assertEquals(1, repository.sentMessages.size)
+        repository.assertRetriedMessageIsFailedOne()
+
+        gate.send(ResultWithError.Success(progress(currentUser, Sending(0))))
+        gate.send(ResultWithError.Success(progress(currentUser, DeliveryStatus.Sent)))
+        gate.close()
+        advanceUntilIdle()
+
+        assertEquals(1, repository.sentMessages.size)
+        val state = viewModel.state.value
+        assertTrue(state is ChatUiState.Ready)
+        assertNull(state.dialogError)
+        assertEquals(DeliveryStatus.Sent, repository.timelineMessage().deliveryStatus)
+    }
+
+    @Test
+    fun `concurrent retry of distinct messages launches a send for each`() = runTest {
+        val baseChat = createTestChat(TEST_CHAT_ID, TEST_CURRENT_USER_ID, TEST_OTHER_USER_ID)
+        val currentUser = baseChat.participants.first { it.isCurrentUser }
+        val secondId = MessageId(UUID.fromString("00000000-0000-0000-0000-000000000005"))
+        fun failed(id: MessageId) = buildTextMessage {
+            this.id = id
+            sender = currentUser
+            recipient = TEST_CHAT_ID
+            createdAt = TEST_INSTANT
+            text = TEXT
+            deliveryStatus = DeliveryStatus.Failed(DeliveryError.NetworkUnavailable)
+        }
+        val chat = baseChat.copy(
+            messages = persistentListOf(failed(FAILED_MESSAGE_ID), failed(secondId)),
+        )
+        val gateA = Channel<ResultWithError<Message, SendMessageRepositoryError>>(Channel.UNLIMITED)
+        val gateB = Channel<ResultWithError<Message, SendMessageRepositoryError>>(Channel.UNLIMITED)
+        val repository = MessengerRepositoryFakeWithTimeline(
+            chat,
+            listOf(gateA.receiveAsFlow(), gateB.receiveAsFlow()),
+        )
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        viewModel.retryMessage(secondId, TEST_INSTANT)
+        advanceUntilIdle()
+
+        assertEquals(2, repository.sentMessages.size)
+        assertEquals(
+            setOf(FAILED_MESSAGE_ID, secondId),
+            repository.sentMessages.map { it.id }.toSet(),
+        )
+
+        gateA.send(ResultWithError.Success(progress(currentUser, Sending(0))))
+        gateA.send(ResultWithError.Success(progress(currentUser, DeliveryStatus.Sent)))
+        gateB.send(ResultWithError.Success(progress(currentUser, Sending(0), secondId)))
+        gateB.send(ResultWithError.Success(progress(currentUser, DeliveryStatus.Sent, secondId)))
+        gateA.close()
+        gateB.close()
+        advanceUntilIdle()
+
+        assertEquals(2, repository.sentMessages.size)
+        val state = viewModel.state.value
+        assertTrue(state is ChatUiState.Ready)
+        assertNull(state.dialogError)
     }
 
     @Test
@@ -219,5 +366,38 @@ class ChatViewModelRetryTest {
         val state = viewModel.state.value
         assertTrue(state is ChatUiState.Ready)
         assertNull(state.dialogError)
+    }
+
+    @Test
+    fun `retry is a no-op for an in-flight Sending message`() = runTest {
+        val (chat, _) = chatWith(Sending(0))
+        val repository = MessengerRepositoryFakeWithTimeline(chat, emptyList())
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+
+        assertTrue(repository.sentMessages.isEmpty())
+        val state = viewModel.state.value
+        assertTrue(state is ChatUiState.Ready)
+        assertNull(state.dialogError)
+    }
+
+    @Test
+    fun `retry is a no-op when chat is not ready`() = runTest {
+        val repository = MessengerRepositoryFake(flowChat = MutableSharedFlow())
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+
+        assertTrue(repository.sentMessages.isEmpty())
+        assertTrue(viewModel.state.value is ChatUiState.Loading)
     }
 }

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelRetryTest.kt
@@ -330,6 +330,40 @@ class ChatViewModelRetryTest {
         val state = viewModel.state.value
         assertTrue(state is ChatUiState.Ready)
         assertNull(state.dialogError)
+        val terminalStatuses = repository.timeline
+            .filterIsInstance<TextMessage>()
+            .associate { it.id to it.deliveryStatus }
+        assertEquals(DeliveryStatus.Sent, terminalStatuses[FAILED_MESSAGE_ID])
+        assertEquals(DeliveryStatus.Sent, terminalStatuses[secondId])
+    }
+
+    @Test
+    fun `retry succeeds under CanNotWriteAfterJoining rule`() = runTest {
+        val (baseChat, currentUser) =
+            chatWith(DeliveryStatus.Failed(DeliveryError.NetworkUnavailable))
+        val chat = baseChat.copy(
+            rules = persistentSetOf(CreateMessageRule.CanNotWriteAfterJoining(5.seconds)),
+        )
+        val retryFlow: Flow<ResultWithError<Message, SendMessageRepositoryError>> = flowOf(
+            ResultWithError.Success(progress(currentUser, Sending(0))),
+            ResultWithError.Success(progress(currentUser, DeliveryStatus.Sent)),
+        )
+        val repository = MessengerRepositoryFakeWithTimeline(chat, listOf(retryFlow))
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        val afterJoinWindow = currentUser.joinedAt + 10.seconds
+        viewModel.retryMessage(FAILED_MESSAGE_ID, afterJoinWindow)
+        advanceUntilIdle()
+
+        assertEquals(1, repository.sentMessages.size)
+        repository.assertRetriedMessageIsFailedOne()
+        val state = viewModel.state.value
+        assertTrue(state is ChatUiState.Ready)
+        assertNull(state.dialogError)
+        assertEquals(DeliveryStatus.Sent, repository.timelineMessage().deliveryStatus)
     }
 
     @Test

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelRetryTest.kt
@@ -423,6 +423,34 @@ class ChatViewModelRetryTest {
     }
 
     @Test
+    fun `retry is a no-op for a failed message sent by another participant`() = runTest {
+        val baseChat = createTestChat(TEST_CHAT_ID, TEST_CURRENT_USER_ID, TEST_OTHER_USER_ID)
+        val otherUser = baseChat.participants.first { !it.isCurrentUser }
+        val foreignFailed = buildTextMessage {
+            id = FAILED_MESSAGE_ID
+            sender = otherUser
+            recipient = TEST_CHAT_ID
+            createdAt = TEST_INSTANT
+            text = TEXT
+            deliveryStatus = DeliveryStatus.Failed(DeliveryError.NetworkUnavailable)
+        }
+        val chat = baseChat.copy(messages = persistentListOf(foreignFailed))
+        val repository = MessengerRepositoryFakeWithTimeline(chat, emptyList())
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+
+        assertTrue(repository.sentMessages.isEmpty())
+        val state = viewModel.state.value
+        assertTrue(state is ChatUiState.Ready)
+        assertNull(state.dialogError)
+    }
+
+    @Test
     fun `retry is a no-op for an in-flight Sending message`() = runTest {
         val (chat, _) = chatWith(Sending(0))
         val repository = MessengerRepositoryFakeWithTimeline(chat, emptyList())

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelRetryTest.kt
@@ -3,6 +3,7 @@ package timur.gilfanov.messenger.ui.screen.chat
 import androidx.lifecycle.SavedStateHandle
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -144,16 +145,12 @@ class ChatViewModelRetryTest {
         advanceUntilIdle()
 
         assertEquals(1, repository.sentMessages.size)
-        val retried = assertIs<TextMessage>(repository.sentMessages.single())
-        assertEquals(FAILED_MESSAGE_ID, retried.id)
-        assertEquals(TEXT, retried.text)
-        assertNull(retried.deliveryStatus)
-        assertEquals(TEST_INSTANT, retried.createdAt)
+        repository.assertRetriedMessageIsFailedOne()
 
         val state = viewModel.state.value
         assertTrue(state is ChatUiState.Ready)
         assertNull(state.dialogError)
-        assertEquals(false, state.isSending)
+        assertFalse(state.isSending)
         assertTrue(effects.isEmpty())
         assertEquals(DeliveryStatus.Sent, repository.timelineMessage().deliveryStatus)
     }
@@ -221,6 +218,29 @@ class ChatViewModelRetryTest {
         viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
         advanceUntilIdle()
         assertEquals(2, repository.sentMessages.size)
+    }
+
+    @Test
+    fun `retry shows dialog when use case rejects status transition`() = runTest {
+        val (chat, currentUser) = chatWith(DeliveryStatus.Failed(DeliveryError.NetworkUnavailable))
+        val invalidRetry: Flow<ResultWithError<Message, SendMessageRepositoryError>> = flowOf(
+            ResultWithError.Success(progress(currentUser, DeliveryStatus.Sent)),
+        )
+        val repository = MessengerRepositoryFakeWithTimeline(chat, listOf(invalidRetry))
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+
+        assertEquals(1, repository.sentMessages.size)
+        repository.assertRetriedMessageIsFailedOne()
+        val afterFailure = viewModel.state.value
+        assertTrue(afterFailure is ChatUiState.Ready)
+        val dialogError = assertIs<ReadyError.SendMessageError>(afterFailure.dialogError)
+        assertIs<SendMessageError.DeliveryStatusUpdateNotValid>(dialogError.error)
     }
 
     @Test

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelRetryTest.kt
@@ -1,0 +1,223 @@
+package timur.gilfanov.messenger.ui.screen.chat
+
+import androidx.lifecycle.SavedStateHandle
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import timur.gilfanov.messenger.annotations.Component
+import timur.gilfanov.messenger.domain.entity.ResultWithError
+import timur.gilfanov.messenger.domain.entity.chat.Chat
+import timur.gilfanov.messenger.domain.entity.chat.Participant
+import timur.gilfanov.messenger.domain.entity.message.DeliveryError
+import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus
+import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Sending
+import timur.gilfanov.messenger.domain.entity.message.Message
+import timur.gilfanov.messenger.domain.entity.message.MessageId
+import timur.gilfanov.messenger.domain.entity.message.TextMessage
+import timur.gilfanov.messenger.domain.entity.message.buildTextMessage
+import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidatorImpl
+import timur.gilfanov.messenger.domain.usecase.chat.MarkMessagesAsReadUseCase
+import timur.gilfanov.messenger.domain.usecase.chat.ReceiveChatUpdatesUseCase
+import timur.gilfanov.messenger.domain.usecase.common.LocalStorageError
+import timur.gilfanov.messenger.domain.usecase.common.RemoteError
+import timur.gilfanov.messenger.domain.usecase.message.GetPagedMessagesUseCase
+import timur.gilfanov.messenger.domain.usecase.message.SendMessageError
+import timur.gilfanov.messenger.domain.usecase.message.SendMessageUseCase
+import timur.gilfanov.messenger.domain.usecase.message.repository.SendMessageRepositoryError
+import timur.gilfanov.messenger.testutil.MainDispatcherRule
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.MessengerRepositoryFakeWithTimeline
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CHAT_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_CURRENT_USER_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.TEST_OTHER_USER_ID
+import timur.gilfanov.messenger.ui.screen.chat.ChatViewModelTestFixtures.createTestChat
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Category(Component::class)
+class ChatViewModelRetryTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    companion object {
+        private val FAILED_MESSAGE_ID =
+            MessageId(UUID.fromString("00000000-0000-0000-0000-000000000004"))
+        private val UNKNOWN_MESSAGE_ID =
+            MessageId(UUID.fromString("00000000-0000-0000-0000-000000000099"))
+        private val TEST_INSTANT = Instant.fromEpochMilliseconds(1000)
+        private const val TEXT = "Test message"
+    }
+
+    private fun chatWith(status: DeliveryStatus): Pair<Chat, Participant> {
+        val baseChat = createTestChat(TEST_CHAT_ID, TEST_CURRENT_USER_ID, TEST_OTHER_USER_ID)
+        val currentUser = baseChat.participants.first { it.isCurrentUser }
+        val message = buildTextMessage {
+            id = FAILED_MESSAGE_ID
+            sender = currentUser
+            recipient = TEST_CHAT_ID
+            createdAt = TEST_INSTANT
+            text = TEXT
+            deliveryStatus = status
+        }
+        return baseChat.copy(messages = persistentListOf(message)) to currentUser
+    }
+
+    private fun progress(sender: Participant, status: DeliveryStatus): TextMessage =
+        buildTextMessage {
+            id = FAILED_MESSAGE_ID
+            this.sender = sender
+            recipient = TEST_CHAT_ID
+            createdAt = TEST_INSTANT
+            text = TEXT
+            deliveryStatus = status
+        }
+
+    private fun createViewModel(repository: MessengerRepositoryFakeWithTimeline): ChatViewModel =
+        ChatViewModel(
+            chatIdUuid = TEST_CHAT_ID.id,
+            savedStateHandle = SavedStateHandle(),
+            sendMessageUseCase = SendMessageUseCase(repository, DeliveryStatusValidatorImpl()),
+            receiveChatUpdatesUseCase = ReceiveChatUpdatesUseCase(repository),
+            getPagedMessagesUseCase = GetPagedMessagesUseCase(repository),
+            markMessagesAsReadUseCase = MarkMessagesAsReadUseCase(repository),
+        )
+
+    @Test
+    fun `retry re-sends same id and text with cleared status and no dialog`() = runTest {
+        val (chat, currentUser) = chatWith(DeliveryStatus.Failed(DeliveryError.NetworkUnavailable))
+        val retryFlow: Flow<ResultWithError<Message, SendMessageRepositoryError>> = flowOf(
+            ResultWithError.Success(progress(currentUser, Sending(0))),
+            ResultWithError.Success(progress(currentUser, DeliveryStatus.Sent)),
+        )
+        val repository = MessengerRepositoryFakeWithTimeline(chat, listOf(retryFlow))
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        val effects = mutableListOf<ChatSideEffect>()
+        backgroundScope.launch { viewModel.effects.collect { effects += it } }
+        advanceUntilIdle()
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+
+        assertEquals(1, repository.sentMessages.size)
+        val retried = assertIs<TextMessage>(repository.sentMessages.single())
+        assertEquals(FAILED_MESSAGE_ID, retried.id)
+        assertEquals(TEXT, retried.text)
+        assertNull(retried.deliveryStatus)
+
+        val state = viewModel.state.value
+        assertTrue(state is ChatUiState.Ready)
+        assertNull(state.dialogError)
+        assertTrue(effects.isEmpty())
+    }
+
+    @Test
+    fun `retry local failure shows dialog and message stays retryable`() = runTest {
+        val (chat, currentUser) = chatWith(DeliveryStatus.Failed(DeliveryError.NetworkUnavailable))
+        val failingRetry: Flow<ResultWithError<Message, SendMessageRepositoryError>> = flowOf(
+            ResultWithError.Success(progress(currentUser, Sending(0))),
+            ResultWithError.Failure(
+                SendMessageRepositoryError.LocalOperationFailed(
+                    LocalStorageError.TemporarilyUnavailable,
+                ),
+            ),
+        )
+        val repository = MessengerRepositoryFakeWithTimeline(chat, listOf(failingRetry))
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+
+        assertEquals(1, repository.sentMessages.size)
+        val afterFailure = viewModel.state.value
+        assertTrue(afterFailure is ChatUiState.Ready)
+        val dialogError = assertIs<ReadyError.SendMessageError>(afterFailure.dialogError)
+        assertIs<SendMessageError.LocalOperationFailed>(dialogError.error)
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+        assertEquals(2, repository.sentMessages.size)
+    }
+
+    @Test
+    fun `retry remote failure stays silent and message stays retryable`() = runTest {
+        val (chat, currentUser) = chatWith(DeliveryStatus.Failed(DeliveryError.NetworkUnavailable))
+        val failingRetry: Flow<ResultWithError<Message, SendMessageRepositoryError>> = flowOf(
+            ResultWithError.Success(progress(currentUser, Sending(0))),
+            ResultWithError.Failure(
+                SendMessageRepositoryError.RemoteOperationFailed(
+                    RemoteError.Failed.NetworkNotAvailable,
+                ),
+            ),
+        )
+        val repository = MessengerRepositoryFakeWithTimeline(chat, listOf(failingRetry))
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+
+        assertEquals(1, repository.sentMessages.size)
+        val afterFailure = viewModel.state.value
+        assertTrue(afterFailure is ChatUiState.Ready)
+        assertNull(afterFailure.dialogError)
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+        assertEquals(2, repository.sentMessages.size)
+    }
+
+    @Test
+    fun `retry is a no-op for unknown message id`() = runTest {
+        val (chat, _) = chatWith(DeliveryStatus.Failed(DeliveryError.NetworkUnavailable))
+        val repository = MessengerRepositoryFakeWithTimeline(chat, emptyList())
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        viewModel.retryMessage(UNKNOWN_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+
+        assertTrue(repository.sentMessages.isEmpty())
+        val state = viewModel.state.value
+        assertTrue(state is ChatUiState.Ready)
+        assertNull(state.dialogError)
+    }
+
+    @Test
+    fun `retry is a no-op for a non-failed message`() = runTest {
+        val (chat, _) = chatWith(DeliveryStatus.Sent)
+        val repository = MessengerRepositoryFakeWithTimeline(chat, emptyList())
+        val viewModel = createViewModel(repository)
+
+        backgroundScope.launch { viewModel.state.collect {} }
+        advanceUntilIdle()
+
+        viewModel.retryMessage(FAILED_MESSAGE_ID, TEST_INSTANT)
+        advanceUntilIdle()
+
+        assertTrue(repository.sentMessages.isEmpty())
+        val state = viewModel.state.value
+        assertTrue(state is ChatUiState.Ready)
+        assertNull(state.dialogError)
+    }
+}

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
@@ -249,6 +249,13 @@ object ChatViewModelTestFixtures {
         val sentMessages = mutableListOf<Message>()
         private var sendCallIndex = 0
 
+        /**
+         * The current observable timeline — exactly what `getPagedMessages` (and therefore the
+         * ViewModel-exposed message list) presents. Deterministic to sample after the test
+         * scheduler is idle, unlike collecting the infinite paged flow.
+         */
+        val timeline: List<Message> get() = chatFlow.value.messages
+
         override suspend fun sendMessage(
             message: Message,
         ): Flow<ResultWithError<Message, SendMessageRepositoryError>> {

--- a/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
+++ b/app/src/test/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModelTestFixtures.kt
@@ -22,6 +22,7 @@ import timur.gilfanov.messenger.domain.entity.auth.AuthTokens
 import timur.gilfanov.messenger.domain.entity.chat.Chat
 import timur.gilfanov.messenger.domain.entity.chat.ChatId
 import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
+import timur.gilfanov.messenger.domain.entity.message.DeliveryError
 import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus
 import timur.gilfanov.messenger.domain.entity.message.DeliveryStatus.Sending
 import timur.gilfanov.messenger.domain.entity.message.Message
@@ -228,6 +229,96 @@ object ChatViewModelTestFixtures {
 
         override fun getPagedMessages(chatId: ChatId): Flow<PagingData<Message>> =
             flowOf(PagingData.empty())
+    }
+
+    /**
+     * Repository fake whose send outcome is scripted per `sendMessage` call while the chat
+     * timeline mirrors each emission. Each [perCallSendFlows] entry drives one send: every
+     * `Success` upserts the message into the observable chat; a `Failure` marks the message
+     * `DeliveryStatus.Failed` in the chat. Lets a test seed a failed timeline message via a
+     * first send and then script a distinct retry outcome.
+     */
+    class MessengerRepositoryFakeWithTimeline(
+        chat: Chat,
+        private val perCallSendFlows:
+        List<Flow<ResultWithError<Message, SendMessageRepositoryError>>>,
+    ) : ChatRepository,
+        MessageRepository {
+
+        private val chatFlow = MutableStateFlow(chat)
+        val sentMessages = mutableListOf<Message>()
+        private var sendCallIndex = 0
+
+        override suspend fun sendMessage(
+            message: Message,
+        ): Flow<ResultWithError<Message, SendMessageRepositoryError>> {
+            sentMessages += message
+            val flow = perCallSendFlows.getOrElse(sendCallIndex++) {
+                flowOf(
+                    Success(
+                        when (message) {
+                            is TextMessage -> message.copy(deliveryStatus = Sending(0))
+                            else -> message
+                        },
+                    ),
+                )
+            }
+            return flow.onEach { result ->
+                delay(10) // to pass immediate state updates, like text input
+                when (result) {
+                    is Success -> upsert(result.data)
+                    is Failure -> markFailed(message.id)
+                }
+            }
+        }
+
+        private fun upsert(message: Message) = chatFlow.update { current ->
+            val messages = current.messages.toMutableList().apply {
+                val index = indexOfFirst { it.id == message.id }
+                if (index != -1) this[index] = message else add(message)
+            }.toPersistentList()
+            current.copy(messages = messages)
+        }
+
+        private fun markFailed(messageId: MessageId) = chatFlow.update { current ->
+            val messages = current.messages.map { existing ->
+                if (existing.id == messageId && existing is TextMessage) {
+                    existing.copy(
+                        deliveryStatus = DeliveryStatus.Failed(DeliveryError.NetworkUnavailable),
+                    )
+                } else {
+                    existing
+                }
+            }.toPersistentList()
+            current.copy(messages = messages)
+        }
+
+        override suspend fun receiveChatUpdates(
+            chatId: ChatId,
+        ): Flow<ResultWithError<Chat, ReceiveChatUpdatesRepositoryError>> =
+            chatFlow.map { Success(it) }
+
+        override fun getPagedMessages(chatId: ChatId): Flow<PagingData<Message>> =
+            chatFlow.map { PagingData.from(it.messages) }
+
+        // Implement other required ChatRepository methods as not implemented for this test
+        override suspend fun flowChatList() = error("Not implemented")
+        override fun isChatListUpdateApplying() = kotlinx.coroutines.flow.flowOf(false)
+        override suspend fun createChat(chat: Chat) = error("Not implemented")
+        override suspend fun deleteChat(chatId: ChatId) = error("Not implemented")
+        override suspend fun joinChat(chatId: ChatId, inviteLink: String?) =
+            error("Not implemented")
+
+        override suspend fun leaveChat(chatId: ChatId) = error("Not implemented")
+        override suspend fun markMessagesAsRead(
+            chatId: ChatId,
+            upToMessageId: MessageId,
+        ): ResultWithError<Unit, MarkMessagesAsReadRepositoryError> = ResultWithError.Success(Unit)
+
+        // Implement other required MessageRepository methods as not implemented for this test
+        override suspend fun editMessage(message: Message) = error("Not implemented")
+        override suspend fun deleteMessage(messageId: MessageId, mode: DeleteMessageMode) =
+            error("Not implemented")
     }
 
     /**

--- a/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/message/SendMessageUseCase.kt
+++ b/core/domain/src/main/kotlin/timur/gilfanov/messenger/domain/usecase/message/SendMessageUseCase.kt
@@ -12,6 +12,7 @@ import timur.gilfanov.messenger.domain.entity.chat.CreateMessageRule.CanNotWrite
 import timur.gilfanov.messenger.domain.entity.chat.CreateMessageRule.Debounce
 import timur.gilfanov.messenger.domain.entity.chat.ParticipantId
 import timur.gilfanov.messenger.domain.entity.message.Message
+import timur.gilfanov.messenger.domain.entity.message.MessageId
 import timur.gilfanov.messenger.domain.entity.message.validation.DeliveryStatusValidator
 import timur.gilfanov.messenger.domain.entity.onFailure
 import timur.gilfanov.messenger.domain.entity.onSuccess
@@ -100,13 +101,20 @@ class SendMessageUseCase(
         }
     }
 
+    /**
+     * The message being (re)sent is excluded from the debounce baseline: a message must never
+     * debounce against its own timeline entry. This is a no-op for a first send (the id is not
+     * yet in the timeline) and is what makes a retry of a failed message succeed instead of
+     * spuriously failing with [WaitDebounce] against the very message it is retrying.
+     */
     private fun checkDebounceRule(
         chat: Chat,
         message: Message,
         now: Instant,
         rule: Debounce,
     ): ResultWithError<Unit, SendMessageError> {
-        val lastMessage = chat.lastMessageBy(message.sender.id) ?: return Success(Unit)
+        val lastMessage = chat.lastMessageBy(message.sender.id, excluding = message.id)
+            ?: return Success(Unit)
         val timeFromLastMessage = now - lastMessage.createdAt
 
         return if (timeFromLastMessage < rule.delay) {
@@ -116,7 +124,8 @@ class SendMessageUseCase(
         }
     }
 
-    private fun Chat.lastMessageBy(participantId: ParticipantId): Message? = messages
-        .filter { it.sender.id == participantId }
-        .maxByOrNull { it.createdAt }
+    private fun Chat.lastMessageBy(participantId: ParticipantId, excluding: MessageId): Message? =
+        messages
+            .filter { it.sender.id == participantId && it.id != excluding }
+            .maxByOrNull { it.createdAt }
 }

--- a/core/domain/src/test/kotlin/timur/gilfanov/messenger/domain/usecase/participant/message/CreateMessageUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/timur/gilfanov/messenger/domain/usecase/participant/message/CreateMessageUseCaseTest.kt
@@ -169,6 +169,55 @@ class CreateMessageUseCaseTest {
     }
 
     @Test
+    fun `debounce excludes the message being re-sent from its own baseline`() = runTest {
+        val customTime = Instant.Companion.fromEpochMilliseconds(1000000)
+        val messageCreatedAt = customTime - 1.seconds
+        val debounceDelay = 30.seconds
+        val messageId = MessageId(UUID.fromString("00000000-0000-0000-0000-000000000007"))
+
+        val participant = buildParticipant {
+            name = ""
+            this.joinedAt = customTime - 10.minutes
+        }
+
+        val timelineEntry = buildMessage {
+            id = messageId
+            sender = participant
+            createdAt = messageCreatedAt
+        }
+
+        val message = buildMessage {
+            id = messageId
+            sender = participant
+            createdAt = messageCreatedAt
+        }
+
+        val chat = buildChat {
+            participants = persistentSetOf(participant)
+            rules = persistentSetOf(CreateMessageRule.Debounce(debounceDelay))
+            messages = persistentListOf(timelineEntry)
+        }
+
+        val repository =
+            RepositoryFake(sendMessageResult = flowOf(ResultWithError.Success(message)))
+        val useCase = SendMessageUseCase(
+            repository = repository,
+            deliveryStatusValidator = DeliveryStatusValidatorFake(),
+        )
+
+        useCase(
+            chat = chat,
+            message = message,
+            now = customTime,
+        ).test {
+            val result = awaitItem()
+            assertIs<ResultWithError.Success<Message, SendMessageError>>(result)
+            assertEquals(message, result.data)
+            awaitComplete()
+        }
+    }
+
+    @Test
     fun `test multiple rules success`() = runTest {
         val customTime = Instant.Companion.fromEpochMilliseconds(1000000)
         val joinedAt = customTime - 10.minutes

--- a/docs/plans/2026-05-18-retry-failed-outgoing-messages.md
+++ b/docs/plans/2026-05-18-retry-failed-outgoing-messages.md
@@ -1,0 +1,145 @@
+# Retry failed outgoing messages (issue #377)
+
+## Overview
+
+- Add a `ChatViewModel.retryMessage(messageId)` action that re-sends a failed outgoing
+  message that is already in the chat timeline.
+- Solves issue #377 ("ChatViewModel retries failed outgoing messages", part of #213,
+  effort:S): today `ChatViewModel` only has `sendMessage()`, which builds a brand-new
+  message from composer input — there is no way to re-send a message that failed.
+- A message that reached an accepted delivery status is added to the timeline; if its send
+  later fails it is persisted as `DeliveryStatus.Failed` and stays visible (commit
+  `cf351c8b` made the message timeline the source of truth for send status). Retry finds
+  that message, re-sends it with the **same id and text** (delivery status reset to `null`
+  so `SendMessageUseCase` accepts it — it rejects non-null status with
+  `DeliveryStatusAlreadySet`), and lets the timeline drive the bubble back through
+  Sending → Sent/Failed.
+
+## Context (from discovery)
+
+- Files/components involved:
+  - `app/src/main/java/timur/gilfanov/messenger/ui/screen/chat/ChatViewModel.kt`
+    (`sendMessage`, `handleSendSuccess`, `handleSendFailure`, `isAcceptedStatus`)
+  - `app/src/main/java/timur/gilfanov/messenger/ui/screen/chat/ChatUiState.kt`
+    (`ChatUiState.Ready`, `ReadyError.SendMessageError`)
+  - `core/domain/.../usecase/message/SendMessageUseCase.kt` (rejects non-null
+    `deliveryStatus`; emits `Success` progress / terminal `Failure`)
+  - `core/domain/.../entity/message/Message.kt`, `DeliveryStatus.kt`, `TextMessage`
+  - `app/src/test/.../ui/screen/chat/ChatViewModelTestFixtures.kt`,
+    `ChatViewModelMessageSendingTest.kt`
+- Related patterns found: MVI (`StateFlow` + `Channel` effects), `ResultWithError`,
+  fixed-UUID/Instant test constants, Turbine `test {}`, `MainDispatcherRule`,
+  `@Category(Component::class)`.
+- Dependencies identified: none new. `SendMessageUseCase`, `MessageRepository`, and the
+  `Message` entity already support retry unchanged.
+
+## Development Approach
+
+- **Testing approach**: Regular (code first, then tests).
+- Complete each task fully (its tests passing) before the next.
+- Make small, focused changes; no refactor of the existing send path.
+- **Every task includes its tests**; all tests must pass before the next task.
+- No KDoc except where the contract is non-obvious — add a short KDoc on `retryMessage`
+  documenting the no-op contract.
+- After editing any source file: `./gradlew ktlintFormat detekt --auto-correct`.
+- Do not modify static-analysis config or add `@Suppress`.
+
+## Testing Strategy
+
+- **Unit tests**: required (Task 3) — retry success, retry local failure (dialog), retry
+  remote failure (silent), no-op for unknown/non-failed id.
+- **E2E tests**: none — this is a ViewModel-only change; UI wiring of a retry tap is tracked
+  separately under #213.
+
+## Progress Tracking
+
+- Mark completed items `[x]` immediately when done.
+- `➕` prefix for newly discovered tasks; `⚠️` for blockers.
+- Keep this file in sync with actual work.
+
+## Implementation Steps
+
+### Task 1: Add `retryMessage` + `handleRetryFailure` to ChatViewModel
+
+- [x] Added public `fun retryMessage(messageId, now)`: single guard
+  `currentChat.takeIf { _state.value is Ready } ?: return`, then
+  `messages.filterIsInstance<TextMessage>().firstOrNull { id match && deliveryStatus is Failed } ?: return`,
+  `failed.copy(deliveryStatus = null)`, launch `sendMessageUseCase(...).collect { Success -> Unit; Failure -> ... }`.
+- [x] Reused existing `handleSendFailure(error, SendProgress(acceptedLocally = true))` for the
+  failure branch instead of a new `handleRetryFailure` — identical policy (dialog unless
+  `RemoteOperationFailed`, `isSending` left unchanged) and avoids the `TooManyFunctions`
+  detekt limit. ➕ Inlined the single-use private `textMessage` helper into `sendMessage` to
+  offset the new function (detekt `thresholdInClasses` = 11, fails at 11).
+- [x] Added a KDoc on `retryMessage` documenting the no-op contract.
+- [x] `./gradlew ktlintFormat detekt --auto-correct` — green
+- [x] `./gradlew :app:compileMockDebugAndroidTestKotlin` — green
+
+### Task 2: Add `MessengerRepositoryFakeWithTimeline` test fixture
+
+- [x] Added `MessengerRepositoryFakeWithTimeline(chat, perCallSendFlows)` to
+  `ChatViewModelTestFixtures.kt`: `chatFlow` MutableStateFlow, `sentMessages`, per-call
+  index; `sendMessage` records the message, selects `perCallSendFlows[index++]` (default
+  single `Success(message Sending(0))`), `.onEach { delay(10); Success -> upsert(data);
+  Failure -> markFailed(message.id) }`; `upsert` replaces-by-id or adds; `markFailed` sets
+  `DeliveryStatus.Failed(DeliveryError.NetworkUnavailable)`; `receiveChatUpdates =
+  chatFlow.map { Success(it) }`; `getPagedMessages = chatFlow.map { PagingData.from(...) }`;
+  other members `error("Not implemented")`, `markMessagesAsRead -> Success(Unit)`,
+  `isChatListUpdateApplying -> flowOf(false)`.
+- [x] `./gradlew ktlintFormat detekt --auto-correct` — green
+
+### Task 3: Retry success + failure unit tests
+
+Created `ChatViewModelRetryTest.kt`, `@Category(Component::class)`, `MainDispatcherRule`,
+fixed constants. ➕ Simpler seed than planned: pre-populate the chat with the failed
+message via `createTestChat(...).copy(messages = persistentListOf(failed))` instead of a
+seed `sendMessage` call — removes the call-0 flow and debounce-timing dependency. A
+`backgroundScope` collector keeps `repeatOnSubscription`/`observeChatUpdates` alive while
+asserting on `state.value`.
+
+- [x] `retry re-sends same id and text with cleared status and no dialog` — retry flow
+  `Success(Sending(0)), Success(Sent)`; asserts `sentMessages.single()` has id ==
+  FAILED_MESSAGE_ID, text equal, `deliveryStatus == null`, final `Ready`,
+  `dialogError == null`, no side effects from retry.
+- [x] `retry local failure shows dialog and message stays retryable` — flow ends
+  `Failure(LocalOperationFailed(TemporarilyUnavailable))`; asserts `dialogError` wraps
+  `SendMessageError.LocalOperationFailed`; second `retryMessage` → `sentMessages.size == 2`.
+- [x] `retry remote failure stays silent and message stays retryable` — flow ends
+  `Failure(RemoteOperationFailed(NetworkNotAvailable))`; asserts `dialogError == null`;
+  second `retryMessage` grows `sentMessages` to 2.
+- [x] `retry is a no-op for unknown message id` — no-failed-match → no send, no dialog.
+- [x] ➕ `retry is a no-op for a non-failed message` — message present but `Sent` → no send.
+- [x] `./gradlew :app:testMockDebugUnitTest --tests "...ChatViewModelRetryTest"` — 5/5 pass
+- [x] `./gradlew ktlintFormat detekt --auto-correct` — green
+
+### Task 4: Verify acceptance criteria & regressions
+
+- [x] Re-checked issue #377 ACs — all satisfied (action exists; reuses id; reuses text;
+  success timeline-driven, input not cleared; failure keeps message Failed & retryable;
+  tests cover success & failure).
+- [x] `./gradlew :app:testMockDebugUnitTest --tests "timur.gilfanov.messenger.ui.screen.chat.*"` — pass, no regressions
+- [x] `./gradlew ktlintFormat detekt --auto-correct` — clean
+- [x] `./gradlew :app:compileMockDebugAndroidTestKotlin` — green
+
+## Technical Details
+
+- `retryMessage` reuses `SendMessageUseCase` unchanged: rules re-validated with `now`,
+  `validate()` still passes (same text), `deliveryStatus == null` clears the
+  `DeliveryStatusAlreadySet` guard.
+- Original `createdAt` preserved via `copy` so the retried message keeps its timeline
+  position; `now` is used only for rule evaluation (matches `sendMessage`).
+- Success branch is intentionally a no-op: the timeline is the source of truth and
+  `currentChat` is refreshed by `receiveChatUpdatesUseCase`; the bubble transitions
+  Sending → Sent without ViewModel state mutation.
+- `handleRetryFailure` treats the message as already accepted (it is in the timeline), so
+  it applies only the post-acceptance dialog rule (`!RemoteOperationFailed → dialog`) and
+  never resets `isSending`.
+
+## Post-Completion
+
+**Manual verification** (optional, on-device):
+- Force-fail a send, confirm the failed bubble re-enters Sending then Sent on retry, input
+  is untouched, a logical failure shows the existing error dialog while a network failure
+  stays silent but remains retryable.
+
+**External system updates**: none. UI wiring of a retry tap on the failed bubble is tracked
+separately under #213.

--- a/docs/plans/2026-05-18-retry-failed-outgoing-messages.md
+++ b/docs/plans/2026-05-18-retry-failed-outgoing-messages.md
@@ -30,14 +30,18 @@
 - Related patterns found: MVI (`StateFlow` + `Channel` effects), `ResultWithError`,
   fixed-UUID/Instant test constants, Turbine `test {}`, `MainDispatcherRule`,
   `@Category(Component::class)`.
-- Dependencies identified: none new. `SendMessageUseCase`, `MessageRepository`, and the
-  `Message` entity already support retry unchanged.
+- Dependencies identified: none new. `MessageRepository` and the `Message` entity support
+  retry unchanged. `SendMessageUseCase` required one minimal change: its debounce baseline
+  must exclude the message being (re)sent (a first send is unaffected since the id is not
+  yet in the timeline) — see Task 1 / Technical Details.
 
 ## Development Approach
 
 - **Testing approach**: Regular (code first, then tests).
 - Complete each task fully (its tests passing) before the next.
-- Make small, focused changes; no refactor of the existing send path.
+- Make small, focused changes. The only send-path change is a minimal, in-scope domain
+  fix: `SendMessageUseCase` now excludes the (re)sent message from its own debounce
+  baseline (see Task 1 / Technical Details). No other refactor of the send path.
 - **Every task includes its tests**; all tests must pass before the next task.
 - No KDoc except where the contract is non-obvious — add a short KDoc on `retryMessage`
   documenting the no-op contract.
@@ -46,8 +50,10 @@
 
 ## Testing Strategy
 
-- **Unit tests**: required (Task 3) — retry success, retry local failure (dialog), retry
-  remote failure (silent), no-op for unknown/non-failed id.
+- **Unit tests**: required (Task 3) — retry success (timeline reaches Sent), retry local
+  failure (dialog), retry remote failure (silent), debounce-baseline regression,
+  same-id/distinct-id concurrent retry, no-op for unknown/non-failed/in-flight id and
+  not-ready chat, plus a domain-layer debounce self-exclusion test.
 - **E2E tests**: none — this is a ViewModel-only change; UI wiring of a retry tap is tracked
   separately under #213.
 
@@ -61,10 +67,20 @@
 
 ### Task 1: Add `retryMessage` + `handleRetryFailure` to ChatViewModel
 
-- [x] Added public `fun retryMessage(messageId, now)`: single guard
+- [x] Added public `fun retryMessage(messageId, now)`: guard
   `currentChat.takeIf { _state.value is Ready } ?: return`, then
-  `messages.filterIsInstance<TextMessage>().firstOrNull { id match && deliveryStatus is Failed } ?: return`,
+  `messages.filterIsInstance<TextMessage>().firstOrNull { id match && deliveryStatus is Failed }`,
   `failed.copy(deliveryStatus = null)`, launch `sendMessageUseCase(...).collect { Success -> Unit; Failure -> ... }`.
+- [x] ➕ Added a per-ViewModel `retryingMessageIds: MutableSet<MessageId>` in-flight guard:
+  the id is added before `launch` (`if (failed == null || !retryingMessageIds.add(messageId)) return`)
+  and removed in a `finally`, so a double-invoke cannot launch concurrent sends for the same
+  message; distinct messages may still retry concurrently. Relies on ViewModel actions being
+  main-thread-confined (no extra synchronization).
+- [x] ➕ Minimal in-scope domain change: `SendMessageUseCase.checkDebounceRule` now excludes
+  the message being (re)sent from the debounce baseline (`Chat.lastMessageBy` takes
+  `excluding: MessageId`). Without it a retry under an active `Debounce` rule spuriously
+  fails with `WaitDebounce` against its own failed timeline entry. A first send is
+  unaffected (id not yet in the timeline).
 - [x] Reused existing `handleSendFailure(error, SendProgress(acceptedLocally = true))` for the
   failure branch instead of a new `handleRetryFailure` — identical policy (dialog unless
   `RemoteOperationFailed`, `isSending` left unchanged) and avoids the `TooManyFunctions`
@@ -96,19 +112,35 @@ seed `sendMessage` call — removes the call-0 flow and debounce-timing dependen
 `backgroundScope` collector keeps `repeatOnSubscription`/`observeChatUpdates` alive while
 asserting on `state.value`.
 
-- [x] `retry re-sends same id and text with cleared status and no dialog` — retry flow
-  `Success(Sending(0)), Success(Sent)`; asserts `sentMessages.single()` has id ==
-  FAILED_MESSAGE_ID, text equal, `deliveryStatus == null`, final `Ready`,
-  `dialogError == null`, no side effects from retry.
-- [x] `retry local failure shows dialog and message stays retryable` — flow ends
+- [x] `retry re-sends same id and text, clears status, and reaches Sent` — retry flow
+  `Success(Sending(0)), Success(Sent)`; asserts the captured sent message has id ==
+  FAILED_MESSAGE_ID, text equal, `deliveryStatus == null`, original `createdAt` preserved,
+  final `Ready`, `dialogError == null`, `isSending == false`, no side effects, timeline Sent.
+- [x] `retry local failure shows dialog and message stays failed and retryable` — flow ends
   `Failure(LocalOperationFailed(TemporarilyUnavailable))`; asserts `dialogError` wraps
-  `SendMessageError.LocalOperationFailed`; second `retryMessage` → `sentMessages.size == 2`.
-- [x] `retry remote failure stays silent and message stays retryable` — flow ends
-  `Failure(RemoteOperationFailed(NetworkNotAvailable))`; asserts `dialogError == null`;
-  second `retryMessage` grows `sentMessages` to 2.
+  `SendMessageError.LocalOperationFailed`, timeline back to `Failed`; second `retryMessage`
+  → `sentMessages.size == 2`. Pins the captured sent message id/status.
+- [x] `retry remote failure stays silent and message stays failed and retryable` — flow ends
+  `Failure(RemoteOperationFailed(NetworkNotAvailable))`; asserts `dialogError == null`,
+  timeline back to `Failed`; second `retryMessage` grows `sentMessages` to 2. Pins the
+  captured sent message id/status.
+- [x] ➕ `retry succeeds under debounce rule despite its own failed timeline entry` — chat
+  has `CreateMessageRule.Debounce(5s)`, retry within the window still sends and reaches
+  `Sent` (ViewModel-level regression guard for the `SendMessageUseCase` debounce-baseline
+  change). Pins the captured sent message id/status.
+- [x] ➕ `concurrent retry of the same message launches only one send` — two `retryMessage`
+  calls against a gated send → `sentMessages.size == 1`, stays 1 after the gate drains.
+- [x] ➕ `concurrent retry of distinct messages launches a send for each` — two distinct
+  failed messages, independently gated → `sentMessages.size == 2` with both ids (verifies
+  the in-flight guard is id-scoped, not a single boolean).
 - [x] `retry is a no-op for unknown message id` — no-failed-match → no send, no dialog.
 - [x] ➕ `retry is a no-op for a non-failed message` — message present but `Sent` → no send.
-- [x] `./gradlew :app:testMockDebugUnitTest --tests "...ChatViewModelRetryTest"` — 5/5 pass
+- [x] ➕ `retry is a no-op for an in-flight Sending message` — message `Sending(0)` → no send.
+- [x] ➕ `retry is a no-op when chat is not ready` — `Loading` state → no send.
+- [x] ➕ Domain test `debounce excludes the message being re-sent from its own baseline` in
+  `CreateMessageUseCaseTest` — pins the `SendMessageUseCase` change at its own layer; the
+  existing `test debounce rule failure` (distinct ids) covers the unchanged first-send path.
+- [x] `./gradlew :app:testMockDebugUnitTest --tests "...ChatViewModelRetryTest"` — all pass
 - [x] `./gradlew ktlintFormat detekt --auto-correct` — green
 
 ### Task 4: Verify acceptance criteria & regressions
@@ -122,17 +154,29 @@ asserting on `state.value`.
 
 ## Technical Details
 
-- `retryMessage` reuses `SendMessageUseCase` unchanged: rules re-validated with `now`,
+- `retryMessage` reuses the `SendMessageUseCase` flow: rules re-validated with `now`,
   `validate()` still passes (same text), `deliveryStatus == null` clears the
-  `DeliveryStatusAlreadySet` guard.
+  `DeliveryStatusAlreadySet` guard. `SendMessageUseCase.checkDebounceRule` was changed to
+  exclude the message being (re)sent from the debounce baseline (`Chat.lastMessageBy` now
+  takes `excluding: MessageId`) — without this a retry under an active `Debounce` rule
+  spuriously fails with `WaitDebounce` against its own failed timeline entry. A first send
+  is unaffected (id not yet in the timeline). `CanNotWriteAfterJoining` needs no analogous
+  change: `checkRules` runs before `repository.sendMessage`, so a message can only be in
+  the timeline (incl. as `Failed`) if it already passed the join rule, and `now - joinedAt`
+  only grows, so a later retry always passes it too.
 - Original `createdAt` preserved via `copy` so the retried message keeps its timeline
   position; `now` is used only for rule evaluation (matches `sendMessage`).
 - Success branch is intentionally a no-op: the timeline is the source of truth and
   `currentChat` is refreshed by `receiveChatUpdatesUseCase`; the bubble transitions
   Sending → Sent without ViewModel state mutation.
-- `handleRetryFailure` treats the message as already accepted (it is in the timeline), so
-  it applies only the post-acceptance dialog rule (`!RemoteOperationFailed → dialog`) and
-  never resets `isSending`.
+- The failure branch reuses `handleSendFailure(error, SendProgress(acceptedLocally = true))`:
+  treating the message as already accepted (it is in the timeline) applies only the
+  post-acceptance dialog rule (`!RemoteOperationFailed → dialog`) and never resets
+  `isSending`.
+- Concurrent-retry safety: `retryMessage` adds `messageId` to a private
+  `retryingMessageIds` set before launching and removes it in a `finally`; a second invoke
+  for an id already in the set is a no-op. Distinct messages may still retry concurrently.
+  ViewModel actions are main-thread-confined so the set needs no extra synchronization.
 
 ## Post-Completion
 


### PR DESCRIPTION
Closes #377

## Summary
Adds retry support for failed outgoing chat messages through the `ChatViewModel` action model. Failed outgoing messages can be retried by `MessageId`, preserving the original id and text while transitioning back through sending state and then to sent or failed based on the retry result.

Retry preserves the original failed outgoing message identity instead of creating a new message. That keeps UI state stable and matches the backend-facing contract that a retry represents another send attempt for the same outgoing message.

## Changes
- Added `ChatViewModel` retry handling for failed outgoing messages.
- Updated send-message domain behavior to allow retrying with an existing message id.
- Added focused retry success and failure coverage for chat ViewModel behavior.
- Added domain test coverage for message creation with a supplied id.
- Documented the implementation plan for retrying failed outgoing messages.

## Important Design Decision
None.

## Testing
- [x] Unit tests added or updated
- [ ] Manually tested
- [x] Edge cases considered

## Screenshots / Demo
N/A. This change updates chat state handling and tests, with no visual UI changes.

## Acceptance criteria
- [x] ViewModel exposes an action to retry a failed outgoing message.
- [x] Retry reuses the failed message id.
- [x] Retry reuses the failed message text.
- [x] Retry success updates state and clears input only after success when applicable.
- [x] Retry failure keeps the message failed and retryable.
- [x] Tests cover retry success and retry failure.

## Breaking Changes
None.

## Follow-ups
None.